### PR TITLE
Fix missing MediaProvider definition

### DIFF
--- a/auth-portal/go.sum
+++ b/auth-portal/go.sum
@@ -1,0 +1,6 @@
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/auth-portal/media_provider.go
+++ b/auth-portal/media_provider.go
@@ -1,0 +1,15 @@
+package main
+
+import "net/http"
+
+// MediaProvider defines the methods required for a media server provider.
+type MediaProvider interface {
+	// Name returns a short identifier for the provider (e.g. "plex").
+	Name() string
+	// StartWeb initiates the provider's web-based authentication flow.
+	StartWeb(w http.ResponseWriter, r *http.Request)
+	// Forward processes authentication submissions or token exchanges.
+	Forward(w http.ResponseWriter, r *http.Request)
+	// IsAuthorized checks if the given user is authorized in the provider's system.
+	IsAuthorized(uuid, username string) (bool, error)
+}

--- a/auth-portal/providers.go
+++ b/auth-portal/providers.go
@@ -16,14 +16,6 @@ import (
 	"time"
 )
 
-/************* Provider interface (unchanged) *************/
-type MediaProvider interface {
-	Name() string
-	StartWeb(w http.ResponseWriter, r *http.Request)
-	Forward(w http.ResponseWriter, r *http.Request)
-	IsAuthorized(uuid, username string) (bool, error)
-}
-
 /************* shared helpers *************/
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
@@ -258,7 +250,7 @@ func (plexProvider) StartWeb(w http.ResponseWriter, r *http.Request) {
 		url.QueryEscape(clientID), url.QueryEscape(pin.Code), url.QueryEscape(forward),
 	)
 	writeJSON(w, http.StatusOK, map[string]any{
-		"ok":      true, "provider": "plex",
+		"ok": true, "provider": "plex",
 		"authUrl": authURL,
 		"pin_id":  pin.ID, "client_id": clientID, "expires_in": 120,
 	})


### PR DESCRIPTION
## Summary
- add `MediaProvider` interface in a dedicated file
- tidy provider implementations by removing inline interface
- check in `go.sum` so builds have module hashes

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be374d03208324a357201768695b1c