### PR TITLE
fix: Enforce MFA_ENFORCE flag during login session creation

### DIFF
--- a/auth-portal/handlers.go
+++ b/auth-portal/handlers.go
@@ -287,6 +287,16 @@ func mfaChallengePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if mfaEnforceForAllUsers {
+		enabled, checkErr := userHasMFAEnabled(claims.UUID, claims.Username)
+		if checkErr != nil {
+			log.Printf("mfa challenge: enforcement lookup failed for %s (%s): %v", strings.TrimSpace(claims.Username), strings.TrimSpace(claims.UUID), checkErr)
+		} else if !enabled {
+			http.Redirect(w, r, "/mfa/enroll?pending=1", http.StatusFound)
+			return
+		}
+	}
+
 	render(w, "mfa_challenge.html", map[string]any{
 		"Username": strings.TrimSpace(claims.Username),
 		"Issuer":   mfaIssuer,


### PR DESCRIPTION
- block full-session cookie issuance when MFA_ENFORCE=1 and the account lacks MFA, forcing the pending-MFA flow
- add requireSessionOrPending guard so enrollment endpoints accept either a real session or the pending MFA cookie and reject anonymous calls
- redirect enforced, unenrolled users from the challenge page back to enrollment to keep them on the correct path