### PR TITLE
fix: Issue a full session cookie once MFA enrollment verification suc…

### DIFF
--- a/auth-portal/mfa_handlers.go
+++ b/auth-portal/mfa_handlers.go
@@ -229,6 +229,19 @@ func mfaEnrollmentVerifyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	username := strings.TrimSpace(usernameFrom(r.Context()))
+	if username == "" {
+		username = strings.TrimSpace(user.Username)
+	}
+	if username == "" {
+		username = uuid
+	}
+	if err := setSessionCookie(w, uuid, username); err != nil {
+		log.Printf("mfa verify: set session failed for %s (%s): %v", username, uuid, err)
+		respondJSON(w, http.StatusInternalServerError, map[string]any{"ok": false, "error": "session setup failed"})
+		return
+	}
+
 	respondJSON(w, http.StatusOK, mfaVerifyResponse{OK: true, RecoveryCodes: recoveryCodes})
 }
 


### PR DESCRIPTION
…ceeds so the login flow completes

- After recovery codes persist, derive the username from context/database, default to UUID if needed
- Set the authenticated session cookie and clear the pending state; bail with 500 if cookie setup fails