### PR TITLE
fix: Harden client IP detection and document trusted proxy setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ SESSION_SECRET=change-me-32+chars-random
 SESSION_COOKIE_DOMAIN=yourdomain.com
 APP_BASE_URL=http://localhost:8089
 
+# Trusted proxy CIDR ranges for forwarded headers (comma separated; leave blank to disable)
+TRUSTED_PROXY_CIDRS=
+
 # Multi-factor authentication
 MFA_ENABLE=1
 MFA_ENFORCE=0
@@ -340,6 +343,7 @@ docker compose --profile ldap up -d --build
 - `DATA_KEY`  base64 32-byte key for sealing provider tokens at rest (required).
 - `MFA_ENABLE` / `MFA_ENFORCE` / `MFA_ISSUER`  multi-factor toggles; see below.
 - `FORCE_SECURE_COOKIE`  set to `1` to force `Secure` on cookies (behind TLS/ingress).
+- `TRUSTED_PROXY_CIDRS`  comma-separated CIDR ranges of proxies allowed to supply `X-Forwarded-For`/`X-Real-IP`; leave empty to rely on `RemoteAddr`.
 - `LOGIN_EXTRA_LINK_URL`  external URL on authorized page.
 - `LOGIN_EXTRA_LINK_TEXT`  text for that authorized-page link.
 - `UNAUTH_REQUEST_EMAIL`  email address for unauthorized page "Request Access" mailto.

--- a/auth-portal-full-stack-dev.env
+++ b/auth-portal-full-stack-dev.env
@@ -4,6 +4,9 @@ SESSION_SECRET=change-me-32+chars-random
 SESSION_COOKIE_DOMAIN=yourdomain.com
 APP_BASE_URL=http://localhost:8089
 
+# Trusted proxy CIDR ranges for forwarded headers (comma separated; leave blank to disable)
+TRUSTED_PROXY_CIDRS=
+
 # Multi-factor authentication
 MFA_ENABLE=1
 MFA_ENFORCE=0

--- a/auth-portal-full-stack-dev_docker-compose.yml
+++ b/auth-portal-full-stack-dev_docker-compose.yml
@@ -50,6 +50,7 @@ services:
     environment:
       # App
       APP_BASE_URL: ${APP_BASE_URL:-http://localhost:8089}
+      TRUSTED_PROXY_CIDRS: ${TRUSTED_PROXY_CIDRS:-}
       SESSION_SECRET: ${SESSION_SECRET:?set-in-.env}
       SESSION_COOKIE_DOMAIN: ${SESSION_COOKIE_DOMAIN:?set-in-.env}
       DATA_KEY: ${DATA_KEY:?set-in-.env}

--- a/auth-portal/logging.go
+++ b/auth-portal/logging.go
@@ -28,7 +28,10 @@ func firstNonEmpty(vals ...string) string {
 }
 
 // Prefer lowercase env for parity with docker-compose; fall back to uppercase.
-var curLevel = parseLogLevel(firstNonEmpty(os.Getenv("log_level"), os.Getenv("LOG_LEVEL")))
+var (
+	curLevel             = parseLogLevel(firstNonEmpty(os.Getenv("log_level"), os.Getenv("LOG_LEVEL")))
+	trustedProxyNetworks = parseTrustedProxies(os.Getenv("TRUSTED_PROXY_CIDRS"))
+)
 
 func parseLogLevel(s string) logLevel {
 	switch strings.ToUpper(strings.TrimSpace(s)) {
@@ -96,24 +99,166 @@ func (s *statusRecorder) Write(b []byte) (int, error) {
 }
 
 func clientIP(r *http.Request) string {
-	if xff := strings.TrimSpace(r.Header.Get("X-Forwarded-For")); xff != "" {
-		parts := strings.Split(xff, ",")
-		for _, part := range parts {
-			ip := strings.TrimSpace(part)
-			if ip != "" {
-				return ip
+	remoteHost, remoteIP := normalizeRemoteAddr(r.RemoteAddr)
+
+	if len(trustedProxyNetworks) == 0 {
+		if remoteIP != nil {
+			return remoteIP.String()
+		}
+		return remoteHost
+	}
+
+	if remoteIP == nil {
+		return remoteHost
+	}
+
+	if !isTrustedProxy(remoteIP) {
+		return remoteIP.String()
+	}
+
+	if ip := clientIPFromForwarded(r.Header.Get("X-Forwarded-For")); ip != "" {
+		return ip
+	}
+
+	if ip := clientIPFromRealIP(r.Header.Get("X-Real-IP")); ip != "" {
+		return ip
+	}
+
+	return remoteIP.String()
+}
+
+func clientIPFromForwarded(header string) string {
+	parts := parseForwardedFor(header)
+	if len(parts) == 0 {
+		return ""
+	}
+
+	for i := len(parts) - 1; i >= 0; i-- {
+		if ip := parseIPCandidate(parts[i]); ip != nil {
+			if !isTrustedProxy(ip) {
+				return ip.String()
 			}
 		}
 	}
 
-	if rip := strings.TrimSpace(r.Header.Get("X-Real-IP")); rip != "" {
-		return rip
+	for _, part := range parts {
+		if ip := parseIPCandidate(part); ip != nil {
+			return ip.String()
+		}
 	}
 
-	host, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr))
-	if err == nil && host != "" {
-		return host
-	}
+	return ""
+}
 
-	return strings.TrimSpace(r.RemoteAddr)
+func clientIPFromRealIP(header string) string {
+	ip := parseIPCandidate(header)
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
+}
+
+func parseForwardedFor(header string) []string {
+	if header == "" {
+		return nil
+	}
+	parts := strings.Split(header, ",")
+	res := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			res = append(res, trimmed)
+		}
+	}
+	return res
+}
+
+func normalizeRemoteAddr(addr string) (string, net.IP) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return "", nil
+	}
+	if ip := parseIPCandidate(addr); ip != nil {
+		return ip.String(), ip
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr, parseIPCandidate(addr)
+	}
+	if host == "" {
+		return addr, nil
+	}
+	ip := parseIPCandidate(host)
+	if ip != nil {
+		return ip.String(), ip
+	}
+	return host, nil
+}
+
+func parseIPCandidate(raw string) net.IP {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	if i := strings.Index(raw, "%"); i != -1 {
+		if strings.Count(raw, ":") >= 2 {
+			raw = raw[:i]
+		}
+	}
+	if ip := net.ParseIP(raw); ip != nil {
+		return ip
+	}
+	host, _, err := net.SplitHostPort(raw)
+	if err == nil {
+		return parseIPCandidate(host)
+	}
+	return nil
+}
+
+func isTrustedProxy(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	for _, network := range trustedProxyNetworks {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseTrustedProxies(raw string) []*net.IPNet {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	networks := make([]*net.IPNet, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if strings.Contains(part, "/") {
+			_, network, parseErr := net.ParseCIDR(part)
+			if parseErr == nil {
+				networks = append(networks, network)
+				continue
+			}
+			log.Printf("Invalid TRUSTED_PROXY_CIDRS entry %q: %v", part, parseErr)
+			continue
+		}
+		ip := parseIPCandidate(part)
+		if ip == nil {
+			log.Printf("Invalid TRUSTED_PROXY_CIDRS entry %q: not an IP or CIDR", part)
+			continue
+		}
+		if v4 := ip.To4(); v4 != nil {
+			copyIP := append(net.IP(nil), v4...)
+			networks = append(networks, &net.IPNet{IP: copyIP, Mask: net.CIDRMask(32, 32)})
+			continue
+		}
+		copyIP := append(net.IP(nil), ip.To16()...)
+		networks = append(networks, &net.IPNet{IP: copyIP, Mask: net.CIDRMask(128, 128)})
+	}
+	return networks
 }

--- a/auth-portal/logging_test.go
+++ b/auth-portal/logging_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func withTrustedProxies(t *testing.T, cidrs string) func() {
+	t.Helper()
+	prev := trustedProxyNetworks
+	trustedProxyNetworks = parseTrustedProxies(cidrs)
+	return func() { trustedProxyNetworks = prev }
+}
+
+func TestClientIPNoTrustedProxyIgnoresForwardedFor(t *testing.T) {
+	cleanup := withTrustedProxies(t, "")
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	req.RemoteAddr = "198.51.100.1:12345"
+	req.Header.Set("X-Forwarded-For", "203.0.113.10")
+
+	if got := clientIP(req); got != "198.51.100.1" {
+		t.Fatalf("expected remote IP, got %q", got)
+	}
+}
+
+func TestClientIPTrustedProxyUsesForwardChain(t *testing.T) {
+	cleanup := withTrustedProxies(t, "198.51.100.0/24")
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	req.RemoteAddr = "198.51.100.2:5000"
+	req.Header.Set("X-Forwarded-For", "203.0.113.10, 198.51.100.3")
+
+	if got := clientIP(req); got != "203.0.113.10" {
+		t.Fatalf("expected client IP from forwarded chain, got %q", got)
+	}
+}
+
+func TestClientIPUntrustedRemoteIgnoresSpoofedForwarded(t *testing.T) {
+	cleanup := withTrustedProxies(t, "198.51.100.0/24")
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
+	req.RemoteAddr = "203.0.113.1:4444"
+	req.Header.Set("X-Forwarded-For", "198.51.100.20")
+
+	if got := clientIP(req); got != "203.0.113.1" {
+		t.Fatalf("expected remote IP when proxy untrusted, got %q", got)
+	}
+}
+
+func TestClientIPTrustedProxyUsesRealIP(t *testing.T) {
+	cleanup := withTrustedProxies(t, "198.51.100.0/24")
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	req.RemoteAddr = "198.51.100.2:6000"
+	req.Header.Set("X-Real-IP", "203.0.113.42")
+
+	if got := clientIP(req); got != "203.0.113.42" {
+		t.Fatalf("expected X-Real-IP when proxy trusted, got %q", got)
+	}
+}
+
+func TestClientIPUntrustedRemoteIgnoresRealIP(t *testing.T) {
+	cleanup := withTrustedProxies(t, "198.51.100.0/24")
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	req.RemoteAddr = "203.0.113.1:6000"
+	req.Header.Set("X-Real-IP", "198.51.100.20")
+
+	if got := clientIP(req); got != "203.0.113.1" {
+		t.Fatalf("expected remote IP when proxy untrusted, got %q", got)
+	}
+}


### PR DESCRIPTION
- require TRUSTED_PROXY_CIDRS before honoring forwarded headers and add parsing helpers/tests for limiter safety
- surface the new variable in sample env/compose configs and explain trusted proxy usage in the README