### PR TITLE
Upgrade AuthPortal build stack to Go 1.25.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@
 - Added same-origin CSRF checks to sensitive POST routes and unified client IP detection for logging and security features.
 - Implemented shared per-IP rate limiting middleware covering login, MFA, and logout endpoints.
 - Updated UI assets and templates to expose MFA enrollment/challenge experiences in the portal.
-- Upgraded build stack: Go 1.25.1 base image with patched OpenSSL 3.3.5 and BusyBox fixes.
+- Upgraded build stack: Go 1.25.3 base image with patched OpenSSL 3.3.5 and BusyBox fixes.
 
 ### Upgrade Notes
-- Rebuild images to pull `modomofn/auth-portal:v2.0.2` (Go 1.25.1 base with patched OpenSSL 3.3.5 and BusyBox).
+- Rebuild images to pull `modomofn/auth-portal:v2.0.2` (Go 1.25.3 base with patched OpenSSL 3.3.5 and BusyBox).
 - Database migrations run automatically at startup to create `user_mfa` and `user_mfa_recovery_codes` tables and related columns.
 - Set `SESSION_COOKIE_DOMAIN` to the host scope you serve AuthPortal from so cookies survive redirects behind proxies.
 - New environment toggles control MFA behaviour: `MFA_ENABLE`, `MFA_ENFORCE`, and `MFA_ISSUER` (defaults provided).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/modomofn/auth-portal.svg)](https://hub.docker.com/r/modomofn/auth-portal)
 [![Docker Image Size](https://img.shields.io/docker/image-size/modomofn/auth-portal/latest)](https://hub.docker.com/r/modomofn/auth-portal)
-[![Go Version](https://img.shields.io/badge/Go-1.25.1%2B-00ADD8?logo=go)](https://go.dev/)
+[![Go Version](https://img.shields.io/badge/Go-1.25.3%2B-00ADD8?logo=go)](https://go.dev/)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL3.0-green.svg)](https://github.com/modom-ofn/auth-portal?tab=GPL-3.0-1-ov-file#readme)
 
 **AuthPortal** is a lightweight, self-hosted authentication gateway built for Plex, Jellyfin, and Emby ecosystems. It provides a unified login experience for media-based communities and home-lab environments—issuing secure, signed sessions for use across your intranet portals and apps.
@@ -74,7 +74,7 @@ AuthPortal authenticates users directly against their connected media server acc
 - **Multi-factor authentication:** Enrollment and challenge flows for TOTP with recovery codes. Toggle enforcement per tenant or per user with MFA_ENABLE/MFA_ENFORCE.
 - **Security hardening:** Same-origin CSRF checks on sensitive POST routes, pending-MFA cookie isolation, configurable SESSION_COOKIE_DOMAIN, and consistent JWT rotation after MFA.
 - **Rate limiting:** Shared per-IP throttles now wrap login, MFA enrollment, and verification endpoints to blunt brute-force attacks.
-- **Platform updates:** Upgraded container stack to Go 1.25.1 with patched OpenSSL/BusyBox layers and refreshed UI assets to surface the MFA experience.
+- **Platform updates:** Upgraded container stack to Go 1.25.3 with patched OpenSSL/BusyBox layers and refreshed UI assets to surface the MFA experience.
 
 ---
 
@@ -451,7 +451,7 @@ CREATE TABLE IF NOT EXISTS pins (
 
 ## Build & Images
 
-- Go: `1.25.1` on `alpine:3.21`.
+- Go: `1.25.3` on `alpine:3.21`.
 - Builder installs `git` + CA certs, runs `go mod download` then `go mod tidy -compat=1.25`, builds with:
     - `-v -x` (verbose), `-buildvcs=false` (avoid VCS scans), `-trimpath`, `-ldflags "-s -w"`.
 - Runtime: `alpine:3.21`, installs CA certs + tzdata, runs as non-root `uid 10001`.
@@ -625,7 +625,7 @@ GPL-3.0  https://opensource.org/license/lgpl-3-0
 
 ## Upgrade Guide (v2.0.2)
 
-1) Rebuild or pull `modomofn/auth-portal:v2.0.2` so you pick up Go 1.25.1 plus the patched OpenSSL 3.3.5 / BusyBox layers.
+1) Rebuild or pull `modomofn/auth-portal:v2.0.2` so you pick up Go 1.25.3 plus the patched OpenSSL 3.3.5 / BusyBox layers.
 2) Set `SESSION_COOKIE_DOMAIN` to the host you serve AuthPortal from (e.g., `auth.example.com`) so session + pending-MFA cookies survive redirect flows.
 3) Decide on MFA posture:
    - Leave `MFA_ENABLE=1` to let users enroll.

--- a/auth-portal/Dockerfile
+++ b/auth-portal/Dockerfile
@@ -1,5 +1,5 @@
 # ---- builder ----
-FROM golang:1.25.1-alpine3.21 AS build
+FROM golang:1.25.3-alpine3.21 AS build
 WORKDIR /src
 
 # Tools needed for fetching modules over HTTPS

--- a/auth-portal/go.mod
+++ b/auth-portal/go.mod
@@ -2,6 +2,8 @@ module auth-portal
 
 go 1.25
 
+toolchain go1.25.3
+
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/gorilla/mux v1.8.1


### PR DESCRIPTION
**Summary**

- bump the builder base image to golang:1.25.3-alpine3.21 so new builds include the patched stdlib release
- add a toolchain go1.25.3 directive to keep local builds on the same security baseline
- refresh changelog, README badges, and upgrade guide to call out the new Go requirement

**Testing**

- Built and ran the edge Docker image from dev; manual auth flows (login, MFA enrollment/challenge) succeeded without regressions
- Tested each provider in sandbox


Only the original busy box CVE still exist, which is already noted in another issue.
<img width="967" height="375" alt="image" src="https://github.com/user-attachments/assets/abe8a381-f9dc-42b8-a86b-47a9171e9691" />
