### PR TITLE
chore: update golang.org/x/crypto to v0.43.0 for CVE-2025-47913

### DIFF
--- a/auth-portal/go.mod
+++ b/auth-portal/go.mod
@@ -12,4 +12,4 @@ require (
 	golang.org/x/time v0.13.0
 )
 
-require golang.org/x/crypto v0.35.0
+require golang.org/x/crypto v0.43.0

--- a/auth-portal/go.sum
+++ b/auth-portal/go.sum
@@ -9,5 +9,7 @@ github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
 golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
+golang.org/x/crypto v0.43.0 h1:dduJYIi3A3KOfdGOHX8AVZ/jGiyPa3IbBozJ5kNuE04=
+golang.org/x/crypto v0.43.0/go.mod h1:BFbav4mRNlXJL4wNeejLpWxB7wMbc79PdRGhWKncxR0=
 golang.org/x/time v0.13.0 h1:eUlYslOIt32DgYD6utsuUeHs4d7AsEYLuIAdg7FlYgI=
 golang.org/x/time v0.13.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=


### PR DESCRIPTION
Raised golang.org/x/crypto from 0.35.0 to 0.43.0 to pick up the upstream fix for the SSH_AGENT_SUCCESS panic vulnerability. Dependency hashes are refreshed accordingly.