### PR TITLE
PR Security/CVE-2025-11-23-Fix to Main

### DIFF
--- a/.github/workflows/build-and-publish-auth-portal.yml
+++ b/.github/workflows/build-and-publish-auth-portal.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Scan image with Trivy
         if: github.event_name != 'pull_request'
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           scan-type: image
           image-ref: ${{ env.IMAGE }}:${{ steps.vars.outputs.sha }}

--- a/auth-portal/go.mod
+++ b/auth-portal/go.mod
@@ -12,4 +12,4 @@ require (
 	golang.org/x/time v0.13.0
 )
 
-require golang.org/x/crypto v0.43.0
+require golang.org/x/crypto v0.45.0

--- a/auth-portal/go.sum
+++ b/auth-portal/go.sum
@@ -11,5 +11,7 @@ golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
 golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
 golang.org/x/crypto v0.43.0 h1:dduJYIi3A3KOfdGOHX8AVZ/jGiyPa3IbBozJ5kNuE04=
 golang.org/x/crypto v0.43.0/go.mod h1:BFbav4mRNlXJL4wNeejLpWxB7wMbc79PdRGhWKncxR0=
+golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
+golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
 golang.org/x/time v0.13.0 h1:eUlYslOIt32DgYD6utsuUeHs4d7AsEYLuIAdg7FlYgI=
 golang.org/x/time v0.13.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=


### PR DESCRIPTION
## Changes
- Bumped golang.org/x/crypto to v0.45.0 to meet the latest CVE guidance (auth-portal/go.mod, auth-portal/go.sum).
- Bumped build dependency aquasecurity/trivy-action to v0.33.1 to meet the latest dependabot recommendations (build-and-publish-auth-portal.yml).

## Testing
- Tested in edge tag.
- Tested in sandbox environment.
- All security scans came back clean.