### PR TITLE
fix: preserve OIDC authorize context across login/MFA and fix callback error redirects

### DIFF
--- a/auth-portal/main.go
+++ b/auth-portal/main.go
@@ -304,12 +304,12 @@ func initProviderDeps() {
 		SetUserAdminByUsername: func(username string, admin bool) error {
 			return setUserAdminByUsername(username, admin, "jellyfin")
 		},
-		FinalizeLogin:                finalizeLoginSession,
-		SetSessionCookie:             setSessionCookie,
-		SetTempSessionCookie:         setTempSessionCookie,
-		SealToken:                    SealToken,
-		Debugf:                       Debugf,
-		Warnf:                        Warnf,
+		FinalizeLogin:        finalizeLoginSession,
+		SetSessionCookie:     setSessionCookie,
+		SetTempSessionCookie: setTempSessionCookie,
+		SealToken:            SealToken,
+		Debugf:               Debugf,
+		Warnf:                Warnf,
 	})
 }
 
@@ -815,7 +815,7 @@ func authMiddleware(next http.Handler) http.Handler {
 		c, err := r.Cookie(sessionCookie)
 
 		if err != nil || c.Value == "" {
-			http.Redirect(w, r, "/", http.StatusFound)
+			http.Redirect(w, r, loginRedirectTarget(r), http.StatusFound)
 			return
 		}
 
@@ -825,7 +825,7 @@ func authMiddleware(next http.Handler) http.Handler {
 
 		if err != nil || !token.Valid {
 			clearSessionCookie(w)
-			http.Redirect(w, r, "/", http.StatusFound)
+			http.Redirect(w, r, loginRedirectTarget(r), http.StatusFound)
 			return
 		}
 
@@ -837,12 +837,28 @@ func authMiddleware(next http.Handler) http.Handler {
 				r = r.WithContext(ctx)
 			} else {
 				clearSessionCookie(w)
-				http.Redirect(w, r, "/", http.StatusFound)
+				http.Redirect(w, r, loginRedirectTarget(r), http.StatusFound)
 				return
 			}
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+func loginRedirectTarget(r *http.Request) string {
+	if r == nil || r.URL == nil {
+		return "/"
+	}
+	if r.Method != http.MethodGet || strings.TrimSpace(r.URL.Path) != "/oidc/authorize" {
+		return "/"
+	}
+	next := strings.TrimSpace(r.URL.RequestURI())
+	if !strings.HasPrefix(next, "/oidc/authorize") {
+		return "/"
+	}
+	q := url.Values{}
+	q.Set("next", next)
+	return "/?" + q.Encode()
 }
 
 func hasValidSession(r *http.Request) bool {

--- a/auth-portal/mfa_handlers.go
+++ b/auth-portal/mfa_handlers.go
@@ -43,6 +43,7 @@ type mfaVerifyResponse struct {
 
 type mfaChallengeVerifyRequest struct {
 	Code string `json:"code"`
+	Next string `json:"next,omitempty"`
 }
 
 type mfaChallengeVerifyResponse struct {
@@ -372,7 +373,7 @@ func mfaChallengeVerifyHandler(w http.ResponseWriter, r *http.Request) {
 
 	respondJSON(w, http.StatusOK, mfaChallengeVerifyResponse{
 		OK:                     true,
-		Redirect:               "/home",
+		Redirect:               sanitizeOIDCContinueTarget(req.Next),
 		RecoveryUsed:           recoveryUsed,
 		RemainingRecoveryCodes: remaining,
 	})
@@ -384,6 +385,30 @@ func normalizeMFACode(code string) string {
 	cleaned = strings.ReplaceAll(cleaned, "-", "")
 	cleaned = strings.ReplaceAll(cleaned, "_", "")
 	return cleaned
+}
+
+func sanitizeOIDCContinueTarget(raw string) string {
+	next := strings.TrimSpace(raw)
+	if next == "" {
+		return "/home"
+	}
+	next = strings.ReplaceAll(next, "\\", "/")
+	if !strings.HasPrefix(next, "/oidc/authorize") {
+		return "/home"
+	}
+	parsed, err := url.Parse(next)
+	if err != nil || parsed.String() == "" || parsed.IsAbs() || parsed.Fragment != "" {
+		return "/home"
+	}
+	if !(strings.HasPrefix(next, "/") && (len(next) == 1 || (next[1] != '/' && next[1] != '\\'))) {
+		return "/home"
+	}
+	return parsed.Path + func() string {
+		if parsed.RawQuery == "" {
+			return ""
+		}
+		return "?" + parsed.RawQuery
+	}()
 }
 
 func respondJSON(w http.ResponseWriter, status int, payload any) {

--- a/auth-portal/oidc_handlers.go
+++ b/auth-portal/oidc_handlers.go
@@ -645,8 +645,14 @@ func writeOIDCRedirectError(w http.ResponseWriter, r *http.Request, redirectURI,
 		writeOIDCError(w, http.StatusBadRequest, code, description)
 		return
 	}
-	if host := strings.TrimSpace(u.Hostname()); host != "" {
-		writeOIDCError(w, http.StatusBadRequest, "invalid_request", "unsafe redirect_uri: must be a relative URL")
+	if u.IsAbs() {
+		scheme := strings.ToLower(strings.TrimSpace(u.Scheme))
+		if (scheme != "https" && scheme != "http") || strings.TrimSpace(u.Hostname()) == "" {
+			writeOIDCError(w, http.StatusBadRequest, "invalid_request", "invalid redirect_uri")
+			return
+		}
+	} else if !(strings.HasPrefix(redirectURI, "/") && (len(redirectURI) == 1 || (redirectURI[1] != '/' && redirectURI[1] != '\\'))) {
+		writeOIDCError(w, http.StatusBadRequest, "invalid_request", "invalid redirect_uri")
 		return
 	}
 	q := u.Query()

--- a/auth-portal/oidc_handlers_test.go
+++ b/auth-portal/oidc_handlers_test.go
@@ -31,8 +31,8 @@ const (
 	testClientName    = "Test App"
 	testCallbackURL   = "https://example.com/callback"
 	testTokenPath     = "/oidc/token"
-	headerContentType = "Content-Type"
-	mimeFormURLEnc    = "application/x-www-form-urlencoded"
+	testHeaderContentType = "Content-Type"
+	mimeFormURLEnc        = "application/x-www-form-urlencoded"
 )
 
 func TestFinishAuthorizeFlowSuccess(t *testing.T) {
@@ -235,7 +235,7 @@ SELECT client_id, client_secret, name, redirect_uris, scopes, grant_types, respo
 	form.Set("client_id", testClientID)
 
 	req := httptest.NewRequest(http.MethodPost, testTokenPath, strings.NewReader(form.Encode()))
-	req.Header.Set(headerContentType, mimeFormURLEnc)
+	req.Header.Set(testHeaderContentType, mimeFormURLEnc)
 
 	rr := httptest.NewRecorder()
 	oidcTokenHandler(rr, req)
@@ -308,7 +308,7 @@ SELECT client_id, client_secret, name, redirect_uris, scopes, grant_types, respo
 	form.Set("client_id", testClientID)
 
 	req := httptest.NewRequest(http.MethodPost, testTokenPath, strings.NewReader(form.Encode()))
-	req.Header.Set(headerContentType, mimeFormURLEnc)
+	req.Header.Set(testHeaderContentType, mimeFormURLEnc)
 
 	rr := httptest.NewRecorder()
 	oidcTokenHandler(rr, req)
@@ -382,7 +382,7 @@ SELECT client_id, client_secret, name, redirect_uris, scopes, grant_types, respo
 	form.Set("client_id", testClientID)
 
 	req := httptest.NewRequest(http.MethodPost, testTokenPath, strings.NewReader(form.Encode()))
-	req.Header.Set(headerContentType, mimeFormURLEnc)
+	req.Header.Set(testHeaderContentType, mimeFormURLEnc)
 
 	rr := httptest.NewRecorder()
 	oidcTokenHandler(rr, req)

--- a/auth-portal/redirect_flow_test.go
+++ b/auth-portal/redirect_flow_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestLoginRedirectTargetPreservesOIDCAuthorizeRequest(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/oidc/authorize?client_id=a&redirect_uri=https%3A%2F%2Fapp.example%2Fcb", nil)
+	got := loginRedirectTarget(req)
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse redirect target: %v", err)
+	}
+	if u.Path != "/" {
+		t.Fatalf("unexpected redirect path: got %q want %q", u.Path, "/")
+	}
+	if u.Query().Get("next") != req.URL.RequestURI() {
+		t.Fatalf("unexpected next value: got %q want %q", u.Query().Get("next"), req.URL.RequestURI())
+	}
+}
+
+func TestLoginRedirectTargetDefaultsForNonOIDC(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/home", nil)
+	if got := loginRedirectTarget(req); got != "/" {
+		t.Fatalf("unexpected redirect target: got %q want %q", got, "/")
+	}
+}
+
+func TestWriteOIDCRedirectErrorAllowsAbsoluteHTTPRedirect(t *testing.T) {
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/oidc/authorize", nil)
+	writeOIDCRedirectError(rr, req, "https://app.example/callback?x=1", "abc", "access_denied", "nope")
+
+	resp := rr.Result()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("unexpected status: got %d want %d", resp.StatusCode, http.StatusFound)
+	}
+	loc := resp.Header.Get("Location")
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("parse location: %v", err)
+	}
+	if u.Scheme != "https" || u.Host != "app.example" || u.Path != "/callback" {
+		t.Fatalf("unexpected redirect location: %q", loc)
+	}
+	if u.Query().Get("error") != "access_denied" {
+		t.Fatalf("missing error query in redirect: %q", loc)
+	}
+	if u.Query().Get("state") != "abc" {
+		t.Fatalf("missing state query in redirect: %q", loc)
+	}
+}
+
+func TestSanitizeOIDCContinueTarget(t *testing.T) {
+	if got := sanitizeOIDCContinueTarget("/oidc/authorize?client_id=x"); got != "/oidc/authorize?client_id=x" {
+		t.Fatalf("unexpected sanitized target: %q", got)
+	}
+	if got := sanitizeOIDCContinueTarget("https://evil.example/oidc/authorize"); got != "/home" {
+		t.Fatalf("expected fallback for absolute URL, got %q", got)
+	}
+	if got := sanitizeOIDCContinueTarget("/home"); got != "/home" {
+		t.Fatalf("expected fallback for non-oidc path, got %q", got)
+	}
+}

--- a/auth-portal/static/login.js
+++ b/auth-portal/static/login.js
@@ -2,6 +2,29 @@
 (() => {
   let lastAuthRedirect = "/home";
 
+  function safeRedirect(path) {
+    try {
+      const dest = new URL(String(path || ""), globalThis.location.origin);
+      if (dest.origin !== globalThis.location.origin) return null;
+      if (dest.protocol !== "http:" && dest.protocol !== "https:") return null;
+      return dest.pathname + dest.search + dest.hash;
+    } catch {
+      return null;
+    }
+  }
+
+  function continueTargetFromLocation() {
+    try {
+      const params = new URLSearchParams(globalThis.location.search || "");
+      const next = params.get("next");
+      const safe = safeRedirect(next);
+      if (!safe || !safe.startsWith("/oidc/authorize")) return null;
+      return safe;
+    } catch {
+      return null;
+    }
+  }
+
   function openPopup(url) {
     const w = 600, h = 700;
     const y = (globalThis.top?.outerHeight || 800) / 2 + (globalThis.top?.screenY || 0) - h / 2;
@@ -14,17 +37,28 @@
   }
 
   function finalizeNavigation(redirect, needsMFA) {
-    const safeRedirect = (path) => {
+    const continueTarget = continueTargetFromLocation();
+    let target = safeRedirect(redirect) || (needsMFA ? "/mfa/challenge" : "/home");
+
+    if (!needsMFA && continueTarget) {
       try {
-        const dest = new URL(String(path || ""), globalThis.location.origin);
-        if (dest.origin !== globalThis.location.origin) return null;
-        if (dest.protocol !== "http:" && dest.protocol !== "https:") return null;
-        return dest.pathname + dest.search + dest.hash;
-      } catch {
-        return null;
-      }
-    };
-    const target = safeRedirect(redirect) || (needsMFA ? "/mfa/challenge" : "/home");
+        const parsed = new URL(target, globalThis.location.origin);
+        if (parsed.pathname === "/home") {
+          target = continueTarget;
+        }
+      } catch {}
+    }
+
+    if (continueTarget) {
+      try {
+        const parsed = new URL(target, globalThis.location.origin);
+        if (parsed.pathname === "/mfa/challenge" && !parsed.searchParams.has("next")) {
+          parsed.searchParams.set("next", continueTarget);
+          target = parsed.pathname + (parsed.search ? parsed.search : "");
+        }
+      } catch {}
+    }
+
     lastAuthRedirect = target;
     globalThis.location.assign(target);
   }

--- a/auth-portal/static/mfa_challenge.js
+++ b/auth-portal/static/mfa_challenge.js
@@ -3,6 +3,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const codeInput = document.getElementById('mfa-code');
   const submitBtn = document.getElementById('mfa-submit');
   const errorBox = document.getElementById('mfa-error');
+  const searchParams = new URLSearchParams(globalThis.location.search || '');
+  const next = (searchParams.get('next') || '').trim();
 
   if (codeInput) {
     setTimeout(() => codeInput.focus({ preventScroll: true }), 50);
@@ -42,7 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
         method: 'POST',
         credentials: 'same-origin',
         headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
-        body: JSON.stringify({ code }),
+        body: JSON.stringify({ code, next }),
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok && data?.ok) {


### PR DESCRIPTION
## Summary

This patch fixes OIDC login continuation and callback error behavior in AuthPortal.

Previously, if a user hit `/oidc/authorize` without an existing portal session, `authMiddleware` redirected to `/` and the original OIDC request context was lost. After login (and optionally MFA), users were sent to `/home` instead of resuming the OIDC authorization request.

This change introduces a `next`-based continuation flow for `/oidc/authorize`, carries it through MFA, and resumes authorization after successful authentication.

It also fixes OIDC error redirect handling so absolute callback URIs receive standards-compliant redirect errors, rather than JSON fallback errors.

A test constant collision was also fixed.

## Changes

- Preserve unauthenticated `GET /oidc/authorize...` as `/?next=<request-uri>` in `authMiddleware`.
- Add `loginRedirectTarget()` to scope preservation logic to OIDC authorize requests.
- Update `static/login.js` to:
  - parse and validate `next`,
  - resume `/oidc/authorize...` after successful login,
  - carry `next` into `/mfa/challenge` when MFA is required.
- Update `static/mfa_challenge.js` to submit `next` with MFA verification.
- Update `mfaChallengeVerifyHandler` to accept `next`, sanitize it, and return it as redirect when valid.
- Add strict `sanitizeOIDCContinueTarget()` validation with `/home` fallback.
- Fix `writeOIDCRedirectError` to allow absolute `http/https` callback redirects and append OAuth error params.
- Add redirect-flow tests in `redirect_flow_test.go`.
- Fix package-level test constant collision in `oidc_handlers_test.go` (`headerContentType` rename).

## Why

- Prevents OIDC authorization context loss when the user must authenticate at AuthPortal first.
- Supports MFA-required users without breaking OIDC handoff.
- Improves OIDC interoperability for clients expecting redirect-based error responses.

## Testing

- Ran `gofmt` on changed Go files.
- Ran full suite:

```bash
DATA_KEY=<32-byte-base64> SESSION_SECRET=<32+ chars> go test ./...
```

- Result: all packages passed.

## Notes

- Redirect URI validation/matching behavior is unchanged: incoming `redirect_uri` must exactly match one of the client’s registered `redirectUris`.