### PR TITLE
feat(admin): add logs tab with consolidated audit history and live log stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # AuthPortal Changelog
 
+## Unreleased
+
+### Highlights
+- Added a dedicated `Logs` admin tab that replaces the older fragmented Recent Changes experience with a single consolidated audit table.
+- Added tab and user filters plus date sorting for recent-change review so operators can quickly isolate admin activity.
+- Added a live admin log stream viewer with explicit start, pause, manual refresh, and configurable auto-refresh behavior; the stream stays off by default until an admin starts it.
+- Added `/api/admin/logs/history` and `/api/admin/logs/stream` endpoints to back the new Logs UI.
+- Expanded persistent server-side audit coverage so Access Control and Backups actions now appear in consolidated admin history alongside config, OAuth, and LDAP-related entries.
+
 ## v2.0.5 - 2026-03-13
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ AuthPortal authenticates users directly against their connected media server acc
   - Access Control tab for RBAC roles, permissions, and manual user-role bindings
   - OAuth client management (list/create/update/delete + secret rotation) with persistent audit history and change reasons
   - Config backup tab with manual exports, scheduled runs (hourly/daily/weekly), retention, and one-click restore/download actions
+  - Logs tab with consolidated recent changes, tab/user filters, date sorting, and a live admin log stream viewer
 
 - **RBAC, app entitlements, and directory mapping**
   - Database-backed roles, permissions, role-permission mappings, and user-role bindings
@@ -67,7 +68,7 @@ AuthPortal authenticates users directly against their connected media server acc
 ### UI Preview
 
 <p align="center">
-  <img src="./screenshots/ui-preview-rotating.gif" alt="Rotating AuthPortal UI preview banner showing authorized and unauthorized views, MFA flow, and admin tabs for providers, security, MFA, app settings, OAuth clients, LDAP Sync, and backups." />
+  <img src="./screenshots/ui-preview-rotating.gif" alt="Rotating AuthPortal UI preview banner showing authorized and unauthorized views, MFA flow, and admin tabs for providers, security, MFA, app settings, OAuth clients, LDAP Sync, backups, and logs." />
 </p>
 
 Frame descriptions (alt text):
@@ -83,6 +84,7 @@ Frame descriptions (alt text):
 10. Admin LDAP Sync tab with connection testing, scheduling, group-role mapping, and run history.
 11. Admin Access Control tab for roles, permissions, and user bindings.
 12. Admin Backups tab with exports, scheduling, retention, and restore actions.
+13. Admin Logs tab with consolidated audit history filters and a live log stream viewer.
 
 ---
 
@@ -131,6 +133,8 @@ Frame descriptions (alt text):
 - **Safe stale-entry cleanup:** optional deletion of stale LDAP records now only targets entries previously marked as AuthPortal-managed under the configured Base DN.
 - **Improved LDAP observability and UX:** per-user sync failures are logged with the affected username, completion summaries are logged per run, and the admin panel now exposes structured connection-test results, Recent Changes integration, and a cleaner sectioned layout.
 - **OpenLDAP bootstrap simplification:** the old `ldap-seed` helper is no longer part of the recommended workflow because AuthPortal can create the configured Base DN when it is missing and creatable.
+- **Dedicated Logs admin tab:** Recent Changes is now consolidated into a single Logs surface with tab/user filters, date sorting, and a live application log stream that admins can start, pause, or refresh on demand.
+- **Expanded server-side audit coverage:** Access Control and Backups actions now emit persistent audit events so the Logs tab reflects real server history instead of browser-local state.
 
 ## What's New in v2.0.4
 
@@ -481,6 +485,14 @@ If you plan to use LDAP Sync, point the LDAP environment variables at your exist
 - App Settings service links can require a selected permission. If no permission is selected, the button is shown to all authorized users.
 - `/whoami` and `/me` now expose the caller's effective roles and permissions for downstream integrations.
 
+### Admin Logs
+
+- The **Logs** tab under `/admin` replaces the older per-tab Recent Changes sidebar/modal with a single consolidated audit view.
+- Recent changes are aggregated across config sections, OAuth client management, Access Control actions, backup actions, and LDAP Sync-related config history.
+- Operators can filter the table by admin tab and acting user, then sort by change date to review older or newer activity first.
+- The live log stream is off by default and only starts polling after an admin explicitly starts it.
+- While streaming, admins can choose an auto-refresh interval; when paused, they can use manual refresh to poll the latest buffered entries.
+
 ### Multi-factor authentication
 
 - `MFA_ENABLE` controls whether users can enroll; leave it `1` when enforcing.
@@ -535,6 +547,7 @@ All providers implement `IsAuthorized(uuid, username)`; success is cached in `me
 - Token sealing: tokens are encrypted with `DATA_KEY` before DB insert/update. Unseal on read; failures clear the in-memory token.
 - Cookies: Session and pending-MFA cookies honour `SESSION_COOKIE_DOMAIN`; they are HTTP-only, SameSite=Lax, and rotate after successful MFA. `Secure` is automatic when `APP_BASE_URL` is HTTPS, or force it with `FORCE_SECURE_COOKIE=1`.
 - Authorization: admin and downstream-app access is enforced through RBAC permissions, not just a legacy admin boolean. Custom app permissions can gate portal links and OAuth scopes.
+- Admin observability: the Logs tab is permission-gated behind admin access, and its recent-changes table is backed by persisted server audit records for OAuth, Access Control, and backup operations.
 - Rate limits: login endpoints share a per-IP limiter (burst 5, ~10 req/min); MFA enrollment/challenge use a tighter burst 3, ~5 req/min (tune in `main.go`).
 - CSRF-lite: POST routes require same-origin via Origin/Referer.
 - Headers:
@@ -610,6 +623,10 @@ DEBUG jellyfin/auth POST http://<server>/Users/AuthenticateByName?format=json
 WARN  emby/auth HTTP 401 body="..."
 DEBUG plex: resources match via machine id
 ```
+- **Admin Logs tab**:
+  - Consolidated audit history is available in the admin UI via the `Logs` tab.
+  - The live stream viewer reads from an in-memory recent log buffer exposed only to authenticated admins.
+  - Streaming is opt-in and disabled by default; admins can start, pause, or manually refresh the view.
 - **Postgres**: `LOG_LEVEL` maps to server params:
   - `DEBUG`  `log_min_messages=debug1`, connection/disconnection logging on
   - `INFO`  `log_min_messages=info`
@@ -662,6 +679,8 @@ DEBUG plex: resources match via machine id
   - `GET /api/admin/ldap-sync`  fetch LDAP sync config, scheduler status, and recent runs.
   - `POST /api/admin/ldap-sync/test-connection`  validate LDAP connectivity and Base DN readiness using the submitted form values without saving them.
   - `POST /api/admin/ldap-sync/run`  trigger a manual LDAP sync run.
+  - `GET /api/admin/logs/history`  fetch consolidated admin audit history across supported tabs.
+  - `GET /api/admin/logs/stream`  fetch the buffered live application log stream for the admin Logs tab.
   - `GET /api/admin/oauth/clients`  list registered OAuth clients.
   - `GET /api/admin/oauth/history`  fetch persistent OAuth Recent Changes audit history.
   - `GET /api/admin/oauth/scopes`  list standard OIDC scopes plus custom RBAC permission scopes.
@@ -733,6 +752,7 @@ DEBUG plex: resources match via machine id
 - OAuth client secrets are hashed with bcrypt before storage; rotate legacy secrets so they’re re-hashed and unusable if the DB or backups leak.
 - Access and refresh tokens are stored as deterministic SHA-256 digests, so leaked database rows don’t expose bearer tokens (rotate outstanding tokens after upgrading).
 - Config backups written to disk are encrypted with the same `DATA_KEY`, so keep that key secret and re-bootstrap older plaintext backups if needed.
+- The admin Logs tab can expose recent operational log lines in-browser to authenticated admins, so avoid logging secrets and keep admin access tightly scoped.
 - Admin flag changes immediately revoke outstanding sessions by bumping an internal session version; reissue cookies after any privilege change.
 - Dont expose Postgres or LDAP externally unless necessary.
 - Keep images and dependencies updated.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ Security fixes are provided for actively maintained release lines. Anything outs
 
 | Version line | Status | Notes |
 | ------------ | ------ | ----- |
-| `v2.0.5` (latest: `v2.0.5`) | ✅ Supported | Receives all security and high-priority bug fixes, including RBAC, LDAP sync, and OAuth/OIDC hardening updates. |
+| `v2.0.5` (latest: `v2.0.5`) | ✅ Supported | Receives all security and high-priority bug fixes, including RBAC, LDAP sync, OAuth/OIDC hardening, and admin logging updates. |
 | `dev` branch | ✅ Supported | Pre-release builds; fixes land here first and are promoted into the next tagged release. |
 | `< v2.0.4` | ❌ End-of-life | Please upgrade to a supported release. |
 
@@ -63,7 +63,9 @@ If you spot an issue or have questions about these scans, please open an issue o
 - **CSRF-lite controls:** every state-changing route (start-web, forward, MFA APIs, logout) passes through an Origin/Referer validator that builds an allowlist from APP_BASE_URL and proxy headers.
 - **Security headers:** all responses carry X-Frame-Options, X-Content-Type-Options, Referrer-Policy, a restrictive CSP, and conditional Strict-Transport-Security (or forceable via FORCE_HSTS).
 - **Config governance:** provider/security/MFA/App Settings/LDAP Sync config lives in Postgres with optimistic versioning, in-browser history, scheduled backups, and download/restore flows for recovery.
+- **Admin audit visibility:** the Logs tab aggregates persisted admin audit history across supported modules and exposes a buffered live log stream only to authenticated admins.
 - **LDAP sync safety rails:** built-in LDAP Sync supports connection testing before save/run, optional LDAP group-to-role mapping, logs per-user failures, tracks scheduled/manual runs, and only deletes stale entries that were previously marked as AuthPortal-managed under the configured Base DN.
 - **Token privacy for OIDC:** access/refresh tokens are stored as deterministic SHA-256 digests, limiting exposure if databases or logs leak.
 - **OAuth governance:** OAuth client changes now produce persistent server-side audit history with operator-supplied change reasons, and custom OAuth scopes are validated against the RBAC permission catalog before they can be assigned or granted.
+- **Operational logging caution:** because the admin Logs tab can surface recent application log lines in-browser, operators should avoid writing secrets to logs and should keep `admin.access` assignments tightly scoped.
 - **Runtime hygiene:** containers are built with Docker Hardened Images for both build and runtime (`dhi.io/golang:1.26.1-alpine3.23-dev` -> `dhi.io/alpine-base:3.23-alpine3.23`), keep only CA certs/tzdata in the final layer, and run as non-root UID 65532 to shrink the attack surface.

--- a/auth-portal/admin_backup_handlers.go
+++ b/auth-portal/admin_backup_handlers.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"auth-portal/configstore"
+
 	"github.com/gorilla/mux"
 )
 
@@ -60,6 +62,7 @@ type adminBackupScheduleRequest struct {
 	Minute    int      `json:"minute"`
 	Sections  []string `json:"sections"`
 	Retention int      `json:"retention"`
+	Reason    string   `json:"reason,omitempty"`
 }
 
 func adminBackupsListHandler(w http.ResponseWriter, r *http.Request) {
@@ -116,6 +119,7 @@ func adminBackupsCreateHandler(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusInternalServerError, map[string]any{"ok": false, "error": "failed to create backup"})
 		return
 	}
+	recordAdminAudit(r.Context(), configstore.SectionBackups, actorFromRequest(r), "Backup created", meta.Name, strings.Join(meta.Sections, ", "), "")
 
 	respondJSON(w, http.StatusCreated, map[string]any{
 		"ok":     true,
@@ -164,6 +168,7 @@ func adminBackupsScheduleUpdate(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusBadRequest, map[string]any{"ok": false, "error": err.Error()})
 		return
 	}
+	recordAdminAudit(r.Context(), configstore.SectionBackups, actor, "Backup schedule updated", updated.Frequency, strings.Join(updated.Sections, ", "), req.Reason)
 
 	respondJSON(w, http.StatusOK, map[string]any{
 		"ok":       true,
@@ -185,6 +190,7 @@ func adminBackupsDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusBadRequest, map[string]any{"ok": false, "error": err.Error()})
 		return
 	}
+	recordAdminAudit(r.Context(), configstore.SectionBackups, actorFromRequest(r), "Backup deleted", name, "", "")
 	respondJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 
@@ -204,6 +210,7 @@ func adminBackupsRestoreHandler(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusBadRequest, map[string]any{"ok": false, "error": err.Error()})
 		return
 	}
+	recordAdminAudit(r.Context(), configstore.SectionBackups, actorFromRequest(r), "Backup restored", name, "", "")
 	respondJSON(w, http.StatusOK, map[string]any{
 		"ok":     true,
 		"config": buildAdminConfigResponse(cfg),

--- a/auth-portal/admin_logs.go
+++ b/auth-portal/admin_logs.go
@@ -1,0 +1,343 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"auth-portal/configstore"
+)
+
+const (
+	adminAuditEventsKey    = "events"
+	adminLogBufferMaxLines = 500
+	adminLogDefaultLimit   = 100
+	adminLogMaxFetchLimit  = 500
+)
+
+type adminAuditPayload struct {
+	Action  string `json:"action"`
+	Subject string `json:"subject,omitempty"`
+	Details string `json:"details,omitempty"`
+}
+
+type adminLogsHistoryEntry struct {
+	Section   string    `json:"section"`
+	Label     string    `json:"label"`
+	Action    string    `json:"action"`
+	Subject   string    `json:"subject,omitempty"`
+	Details   string    `json:"details,omitempty"`
+	Version   int64     `json:"version,omitempty"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	UpdatedBy string    `json:"updatedBy,omitempty"`
+}
+
+type adminLogsHistoryResponse struct {
+	OK      bool                    `json:"ok"`
+	Entries []adminLogsHistoryEntry `json:"entries"`
+}
+
+type adminLogStreamEntry struct {
+	ID        int64     `json:"id"`
+	Timestamp time.Time `json:"timestamp"`
+	Message   string    `json:"message"`
+}
+
+type adminLogStreamResponse struct {
+	OK      bool                  `json:"ok"`
+	Cursor  int64                 `json:"cursor"`
+	Entries []adminLogStreamEntry `json:"entries"`
+}
+
+type adminLogTap struct {
+	mu      sync.Mutex
+	max     int
+	nextID  int64
+	lines   []adminLogStreamEntry
+	partial bytes.Buffer
+}
+
+func newAdminLogTap(max int) *adminLogTap {
+	if max <= 0 {
+		max = adminLogBufferMaxLines
+	}
+	return &adminLogTap{max: max}
+}
+
+func (t *adminLogTap) Write(p []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for _, b := range p {
+		if b == '\n' {
+			t.flushLocked()
+			continue
+		}
+		_ = t.partial.WriteByte(b)
+	}
+	return len(p), nil
+}
+
+func (t *adminLogTap) flushLocked() {
+	line := strings.TrimRight(t.partial.String(), "\r")
+	t.partial.Reset()
+	if strings.TrimSpace(line) == "" {
+		return
+	}
+	t.nextID++
+	t.lines = append(t.lines, adminLogStreamEntry{
+		ID:        t.nextID,
+		Timestamp: time.Now().UTC(),
+		Message:   line,
+	})
+	if len(t.lines) > t.max {
+		t.lines = append([]adminLogStreamEntry(nil), t.lines[len(t.lines)-t.max:]...)
+	}
+}
+
+func (t *adminLogTap) since(afterID int64, limit int) ([]adminLogStreamEntry, int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.partial.Len() > 0 {
+		t.flushLocked()
+	}
+	if limit <= 0 || limit > adminLogMaxFetchLimit {
+		limit = adminLogDefaultLimit
+	}
+
+	filtered := make([]adminLogStreamEntry, 0, minInt(limit, len(t.lines)))
+	for _, entry := range t.lines {
+		if entry.ID <= afterID {
+			continue
+		}
+		filtered = append(filtered, entry)
+		if len(filtered) >= limit {
+			break
+		}
+	}
+	return filtered, t.nextID
+}
+
+var (
+	adminLogStream = newAdminLogTap(adminLogBufferMaxLines)
+	adminLogOnce   sync.Once
+)
+
+func installAdminLogBuffer() {
+	adminLogOnce.Do(func() {
+		log.SetOutput(io.MultiWriter(os.Stderr, adminLogStream))
+	})
+}
+
+func recordAdminAudit(ctx context.Context, section configstore.Section, actor, action, subject, details, reason string) {
+	if configStore == nil {
+		return
+	}
+	action = strings.TrimSpace(action)
+	subject = strings.TrimSpace(subject)
+	details = strings.TrimSpace(details)
+	reason = strings.TrimSpace(reason)
+	if action == "" {
+		return
+	}
+	if reason == "" {
+		reason = action
+		if subject != "" {
+			reason = fmt.Sprintf("%s: %s", reason, subject)
+		}
+		if details != "" {
+			reason = fmt.Sprintf("%s (%s)", reason, details)
+		}
+	}
+	if err := configStore.AppendHistory(ctx, section, adminAuditPayload{
+		Action:  action,
+		Subject: subject,
+		Details: details,
+	}, configstore.UpdateOptions{
+		Key:       adminAuditEventsKey,
+		UpdatedBy: strings.TrimSpace(actor),
+		Reason:    sanitizeAdminReason(reason),
+	}); err != nil {
+		log.Printf("admin audit failed for %s: %v", section, err)
+	}
+}
+
+func adminLogsHistoryHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		respondJSON(w, http.StatusMethodNotAllowed, map[string]any{"ok": false, "error": errMethodNotAllowed})
+		return
+	}
+	if configStore == nil {
+		respondJSON(w, http.StatusInternalServerError, map[string]any{"ok": false, "error": "config store unavailable"})
+		return
+	}
+
+	limit := adminLogDefaultLimit
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v > 0 {
+			limit = v
+		}
+	}
+	if limit > adminLogMaxFetchLimit {
+		limit = adminLogMaxFetchLimit
+	}
+
+	type historySource struct {
+		section configstore.Section
+		output  string
+		key     string
+		label   string
+		action  string
+	}
+	sources := []historySource{
+		{section: configstore.SectionProviders, output: "providers", key: configstore.SectionDocumentKey, label: "Providers", action: "Configuration updated"},
+		{section: configstore.SectionSecurity, output: "security", key: configstore.SectionDocumentKey, label: "Security", action: "Configuration updated"},
+		{section: configstore.SectionMFA, output: "mfa", key: configstore.SectionDocumentKey, label: "MFA", action: "Configuration updated"},
+		{section: configstore.SectionAppSettings, output: "app-settings", key: configstore.SectionDocumentKey, label: "App Settings", action: "Configuration updated"},
+		{section: configstore.SectionOAuth, output: "oauth", key: oauthHistoryKey, label: "OAuth Clients"},
+		{section: configstore.SectionLDAPSync, output: "ldap-sync", key: configstore.SectionDocumentKey, label: "LDAP Sync", action: "Configuration updated"},
+		{section: configstore.SectionBackups, output: "backups", key: adminAuditEventsKey, label: "Backups"},
+		{section: configstore.SectionRBAC, output: "access-control", key: adminAuditEventsKey, label: "Access Control"},
+	}
+
+	entries := make([]adminLogsHistoryEntry, 0, limit)
+	for _, source := range sources {
+		history, err := configStore.History(r.Context(), source.section, source.key, limit)
+		if err != nil {
+			log.Printf("admin logs history failed for %s/%s: %v", source.section, source.key, err)
+			respondJSON(w, http.StatusInternalServerError, map[string]any{"ok": false, "error": "history lookup failed"})
+			return
+		}
+		for _, item := range history {
+			entry := adminLogsHistoryEntry{
+				Section:   source.output,
+				Label:     source.label,
+				Action:    source.action,
+				Version:   item.Version,
+				UpdatedAt: item.UpdatedAt.UTC(),
+				UpdatedBy: strings.TrimSpace(item.UpdatedBy),
+				Details:   strings.TrimSpace(item.Reason),
+			}
+			if source.key == configstore.SectionDocumentKey {
+				if entry.Action == "" {
+					entry.Action = "Configuration updated"
+				}
+			} else {
+				entry = mergeAuditPayload(entry, item.Value)
+				if entry.Action == "" {
+					entry.Action = "Updated"
+				}
+				if entry.Details == "" {
+					entry.Details = strings.TrimSpace(item.Reason)
+				}
+			}
+			entries = append(entries, entry)
+		}
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].UpdatedAt.Equal(entries[j].UpdatedAt) {
+			return entries[i].Version > entries[j].Version
+		}
+		return entries[i].UpdatedAt.After(entries[j].UpdatedAt)
+	})
+	if len(entries) > limit {
+		entries = entries[:limit]
+	}
+
+	respondJSON(w, http.StatusOK, adminLogsHistoryResponse{
+		OK:      true,
+		Entries: entries,
+	})
+}
+
+func mergeAuditPayload(entry adminLogsHistoryEntry, raw json.RawMessage) adminLogsHistoryEntry {
+	var payload adminAuditPayload
+	if len(raw) == 0 || json.Unmarshal(raw, &payload) != nil {
+		return entry
+	}
+	if action := strings.TrimSpace(payload.Action); action != "" {
+		entry.Action = action
+	}
+	if subject := strings.TrimSpace(payload.Subject); subject != "" {
+		entry.Subject = subject
+	}
+	if details := strings.TrimSpace(payload.Details); details != "" {
+		entry.Details = details
+	}
+	var rawFields map[string]any
+	if json.Unmarshal(raw, &rawFields) == nil {
+		if entry.Subject == "" {
+			if name := stringifyAuditField(rawFields["name"]); name != "" {
+				entry.Subject = name
+			} else if clientID := stringifyAuditField(rawFields["clientId"]); clientID != "" {
+				entry.Subject = clientID
+			}
+		}
+		if entry.Details == "" {
+			if clientID := stringifyAuditField(rawFields["clientId"]); clientID != "" && clientID != entry.Subject {
+				entry.Details = clientID
+			}
+		}
+	}
+	return entry
+}
+
+func stringifyAuditField(value any) string {
+	if value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	default:
+		return strings.TrimSpace(fmt.Sprintf("%v", typed))
+	}
+}
+
+func adminLogsStreamHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		respondJSON(w, http.StatusMethodNotAllowed, map[string]any{"ok": false, "error": errMethodNotAllowed})
+		return
+	}
+
+	var (
+		cursor int64
+		limit  = adminLogDefaultLimit
+	)
+	if raw := strings.TrimSpace(r.URL.Query().Get("cursor")); raw != "" {
+		if v, err := strconv.ParseInt(raw, 10, 64); err == nil && v >= 0 {
+			cursor = v
+		}
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v > 0 {
+			limit = v
+		}
+	}
+
+	entries, latestCursor := adminLogStream.since(cursor, limit)
+	respondJSON(w, http.StatusOK, adminLogStreamResponse{
+		OK:      true,
+		Cursor:  latestCursor,
+		Entries: entries,
+	})
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/auth-portal/admin_rbac_handlers.go
+++ b/auth-portal/admin_rbac_handlers.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strings"
 
+	"auth-portal/configstore"
+
 	"github.com/gorilla/mux"
 )
 
@@ -25,11 +27,13 @@ type adminRBACRoleRequest struct {
 	Name        string   `json:"name"`
 	Description string   `json:"description,omitempty"`
 	Permissions []string `json:"permissions"`
+	Reason      string   `json:"reason,omitempty"`
 }
 
 type adminRBACPermissionRequest struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
+	Reason      string `json:"reason,omitempty"`
 }
 
 func loadAdminRBACResponse() (adminRBACResponse, error) {
@@ -96,6 +100,11 @@ func adminRBACBindingUpsertHandler(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, status, map[string]any{"ok": false, "error": err.Error()})
 		return
 	}
+	details := strings.Join(normalizeAdminStringList(req.Roles), ", ")
+	if details == "" {
+		details = "manual roles cleared"
+	}
+	recordAdminAudit(r.Context(), configstore.SectionRBAC, actor, "Manual role binding updated", req.Username, details, req.Reason)
 
 	resp, err := loadAdminRBACResponse()
 	if err != nil {
@@ -130,6 +139,7 @@ func adminRBACRoleCreateHandler(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, status, map[string]any{"ok": false, "error": err.Error()})
 		return
 	}
+	recordAdminAudit(r.Context(), configstore.SectionRBAC, actorFromRequest(r), "Role created", req.Name, strings.Join(normalizeAdminStringList(req.Permissions), ", "), req.Reason)
 
 	resp, err := loadAdminRBACResponse()
 	if err != nil {
@@ -168,6 +178,7 @@ func adminRBACRoleUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, status, map[string]any{"ok": false, "error": err.Error()})
 		return
 	}
+	recordAdminAudit(r.Context(), configstore.SectionRBAC, actorFromRequest(r), "Role updated", req.Name, strings.Join(normalizeAdminStringList(req.Permissions), ", "), req.Reason)
 
 	resp, err := loadAdminRBACResponse()
 	if err != nil {
@@ -183,7 +194,8 @@ func adminRBACRoleDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := deleteRoleDefinition(strings.TrimSpace(mux.Vars(r)["name"])); err != nil {
+	name := strings.TrimSpace(mux.Vars(r)["name"])
+	if err := deleteRoleDefinition(name); err != nil {
 		status := http.StatusInternalServerError
 		if strings.Contains(strings.ToLower(err.Error()), "required") ||
 			strings.Contains(strings.ToLower(err.Error()), "unknown") ||
@@ -193,6 +205,7 @@ func adminRBACRoleDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, status, map[string]any{"ok": false, "error": err.Error()})
 		return
 	}
+	recordAdminAudit(r.Context(), configstore.SectionRBAC, actorFromRequest(r), "Role deleted", name, "", "")
 
 	resp, err := loadAdminRBACResponse()
 	if err != nil {
@@ -223,6 +236,7 @@ func adminRBACPermissionCreateHandler(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, status, map[string]any{"ok": false, "error": err.Error()})
 		return
 	}
+	recordAdminAudit(r.Context(), configstore.SectionRBAC, actorFromRequest(r), "Permission created", req.Name, strings.TrimSpace(req.Description), req.Reason)
 
 	resp, err := loadAdminRBACResponse()
 	if err != nil {
@@ -257,6 +271,7 @@ func adminRBACPermissionUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, status, map[string]any{"ok": false, "error": err.Error()})
 		return
 	}
+	recordAdminAudit(r.Context(), configstore.SectionRBAC, actorFromRequest(r), "Permission updated", req.Name, strings.TrimSpace(req.Description), req.Reason)
 
 	resp, err := loadAdminRBACResponse()
 	if err != nil {
@@ -272,7 +287,8 @@ func adminRBACPermissionDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := deletePermissionDefinition(strings.TrimSpace(mux.Vars(r)["name"])); err != nil {
+	name := strings.TrimSpace(mux.Vars(r)["name"])
+	if err := deletePermissionDefinition(name); err != nil {
 		status := http.StatusInternalServerError
 		if strings.Contains(strings.ToLower(err.Error()), "required") ||
 			strings.Contains(strings.ToLower(err.Error()), "unknown") ||
@@ -282,6 +298,7 @@ func adminRBACPermissionDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, status, map[string]any{"ok": false, "error": err.Error()})
 		return
 	}
+	recordAdminAudit(r.Context(), configstore.SectionRBAC, actorFromRequest(r), "Permission deleted", name, "", "")
 
 	resp, err := loadAdminRBACResponse()
 	if err != nil {

--- a/auth-portal/configstore/store.go
+++ b/auth-portal/configstore/store.go
@@ -23,6 +23,7 @@ const (
 	SectionLDAPSync    Section = "ldap-sync"
 	SectionBackups     Section = "backups"
 	SectionOAuth       Section = "oauth"
+	SectionRBAC        Section = "rbac"
 
 	// SectionDocumentKey is the default key used to persist a full section document.
 	SectionDocumentKey = "__doc"

--- a/auth-portal/logging.go
+++ b/auth-portal/logging.go
@@ -4,7 +4,9 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -31,6 +33,30 @@ func firstNonEmpty(vals ...string) string {
 var (
 	curLevel             = parseLogLevel(firstNonEmpty(os.Getenv("log_level"), os.Getenv("LOG_LEVEL")))
 	trustedProxyNetworks = parseTrustedProxies(os.Getenv("TRUSTED_PROXY_CIDRS"))
+	sensitiveLogKeys     = map[string]struct{}{
+		"accesstoken":   {},
+		"access_token":  {},
+		"api_key":       {},
+		"apikey":        {},
+		"authorization": {},
+		"auth_token":    {},
+		"client_secret": {},
+		"code":          {},
+		"cookie":        {},
+		"idtoken":       {},
+		"id_token":      {},
+		"password":      {},
+		"refreshtoken":  {},
+		"refresh_token": {},
+		"secret":        {},
+		"state":         {},
+		"token":         {},
+		"x-plex-token":  {},
+	}
+	authHeaderPattern  = regexp.MustCompile(`(?i)(authorization["=: ]+(?:[A-Za-z]+ )?)([^",\s]+)`)
+	cookiePattern      = regexp.MustCompile(`(?i)(cookie["=: ]+)([^",\s]+)`)
+	jsonSecretPattern  = regexp.MustCompile(`(?i)("?(?:accesstoken|access_token|password|secret|client_secret|refreshtoken|refresh_token|idtoken|id_token|token|apikey|api_key|authorization)"?\s*:\s*")([^"]+)(")`)
+	querySecretPattern = regexp.MustCompile(`(?i)((?:password|secret|token|apikey|api_key|client_secret|refresh_token|access_token)=)([^&\s]+)`)
 )
 
 func parseLogLevel(s string) logLevel {
@@ -81,8 +107,35 @@ func WithRequestLogging(next http.Handler) http.Handler {
 		next.ServeHTTP(rec, r)
 		dur := time.Since(start).Round(time.Millisecond)
 		Debugf(`http %s %s -> %d %dB in %s ua=%q ip=%s`,
-			r.Method, r.URL.RequestURI(), rec.status, rec.written, dur, r.UserAgent(), clientIP(r))
+			r.Method, sanitizeLoggedRequestURI(r.URL), rec.status, rec.written, dur, r.UserAgent(), clientIP(r))
 	})
+}
+
+func sanitizeLoggedRequestURI(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	cloned := *u
+	query := cloned.Query()
+	for key := range query {
+		if _, ok := sensitiveLogKeys[strings.ToLower(strings.TrimSpace(key))]; ok {
+			query.Set(key, "[REDACTED]")
+		}
+	}
+	cloned.RawQuery = query.Encode()
+	return sanitizeLoggedText(cloned.RequestURI())
+}
+
+func sanitizeLoggedText(raw string) string {
+	sanitized := strings.TrimSpace(raw)
+	if sanitized == "" {
+		return sanitized
+	}
+	sanitized = authHeaderPattern.ReplaceAllString(sanitized, `${1}[REDACTED]`)
+	sanitized = cookiePattern.ReplaceAllString(sanitized, `${1}[REDACTED]`)
+	sanitized = jsonSecretPattern.ReplaceAllString(sanitized, `${1}[REDACTED]${3}`)
+	sanitized = querySecretPattern.ReplaceAllString(sanitized, `${1}[REDACTED]`)
+	return sanitized
 }
 
 type statusRecorder struct {

--- a/auth-portal/logging_test.go
+++ b/auth-portal/logging_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -76,6 +77,35 @@ func TestClientIPUntrustedRemoteIgnoresRealIP(t *testing.T) {
 	if got := clientIP(req); got != "203.0.113.1" {
 		t.Fatalf("expected remote IP when proxy untrusted, got %q", got)
 	}
+}
+
+func TestSanitizeLoggedRequestURIRedactsSensitiveQueryValues(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/oidc/callback?code=abc123&state=opaque&client_id=public", nil)
+
+	got := sanitizeLoggedRequestURI(req.URL)
+	if got != "/oidc/callback?client_id=public&code=%5BREDACTED%5D&state=%5BREDACTED%5D" {
+		t.Fatalf("unexpected sanitized URI: %q", got)
+	}
+}
+
+func TestSanitizeLoggedTextRedactsTokenLikeValues(t *testing.T) {
+	raw := `Authorization Bearer abc123 password=hunter2 access_token=xyz`
+	got := sanitizeLoggedText(raw)
+	if got == raw {
+		t.Fatalf("expected sanitized output to differ")
+	}
+	if containsAny(got, "abc123", "hunter2", "xyz") {
+		t.Fatalf("expected sensitive values to be redacted, got %q", got)
+	}
+}
+
+func containsAny(haystack string, needles ...string) bool {
+	for _, needle := range needles {
+		if needle != "" && strings.Contains(haystack, needle) {
+			return true
+		}
+	}
+	return false
 }
 
 const (

--- a/auth-portal/main.go
+++ b/auth-portal/main.go
@@ -179,6 +179,7 @@ func dbChecker(db *sql.DB) health.Checker {
 
 func main() {
 	appTimeZone, appLocation = resolveLocation(appTimeZone)
+	installAdminLogBuffer()
 
 	db = mustInitDB(os.Getenv("DATABASE_URL"))
 	var runtimeCfg RuntimeConfig
@@ -545,6 +546,8 @@ func registerAdminRoutes(r *mux.Router) {
 	adminAPI.Handle("/config/history/{section}", adminProtected(permissionConfigRead, http.HandlerFunc(adminConfigHistoryHandler))).Methods("GET")
 	adminAPI.Handle("/oauth/clients", adminProtected(permissionOAuthRead, http.HandlerFunc(adminOAuthClientsList))).Methods("GET")
 	adminAPI.Handle("/oauth/history", adminProtected(permissionOAuthRead, http.HandlerFunc(adminOAuthHistoryHandler))).Methods("GET")
+	adminAPI.Handle("/logs/history", adminProtected(permissionAdminAccess, http.HandlerFunc(adminLogsHistoryHandler))).Methods("GET")
+	adminAPI.Handle("/logs/stream", adminProtected(permissionAdminAccess, http.HandlerFunc(adminLogsStreamHandler))).Methods("GET")
 	adminAPI.Handle("/oauth/scopes", adminProtected(permissionOAuthRead, http.HandlerFunc(adminOAuthScopeCatalogHandler))).Methods("GET")
 	adminAPI.Handle("/oauth/clients", adminProtected(permissionOAuthWrite, http.HandlerFunc(adminOAuthClientCreate))).Methods("POST")
 	adminAPI.Handle("/oauth/clients/{id}", adminProtected(permissionOAuthWrite, http.HandlerFunc(adminOAuthClientUpdate))).Methods("PUT")

--- a/auth-portal/providers/emby.go
+++ b/auth-portal/providers/emby.go
@@ -341,7 +341,7 @@ func embyGetUserDetail(serverURL, token, userID string) (embyUserDetail, error) 
 func embyAuthenticate(serverURL, clientID, username, password string) (mediaAuthResp, error) {
 	base := strings.TrimSuffix(serverURL, "/")
 	if Debugf != nil {
-		Debugf("emby/auth start server=%s user=%q", base, username)
+		Debugf("emby/auth start server=%s user=%q", redactURLForLog(base), username)
 	}
 	// Try the form-style keys first (matches Emby Web patterns)
 	out, err := mediaAuthAttempt("emby", base, EmbyAppName, EmbyAppVersion, clientID, map[string]string{

--- a/auth-portal/providers/httpx.go
+++ b/auth-portal/providers/httpx.go
@@ -19,15 +19,6 @@ func mediaAuthHeader(appName, appVersion, clientID string) string {
 	return fmt.Sprintf(`MediaBrowser Client="%s", Device="Web", DeviceId="%s", Version="%s"`, appName, clientID, appVersion)
 }
 
-// snippet returns a trimmed preview of a payload for logging/errors.
-func snippet(b []byte, n int) string {
-	s := strings.TrimSpace(string(b))
-	if len(s) > n {
-		return s[:n]
-	}
-	return s
-}
-
 func doWithRetry(req *http.Request) (*http.Response, error) {
 	var resp *http.Response
 	var err error
@@ -113,7 +104,7 @@ func mediaAuthAttempt(prefix, baseURL, appName, appVersion, clientID string, bod
 		return mediaAuthResp{}, err
 	}
 	if Debugf != nil {
-		Debugf("%s/auth POST %s", prefix, req.URL.String())
+		Debugf("%s/auth POST %s", prefix, redactURLForLog(req.URL.String()))
 	}
 	resp, err := doWithRetry(req)
 	if err != nil {
@@ -126,14 +117,14 @@ func mediaAuthAttempt(prefix, baseURL, appName, appVersion, clientID string, bod
 	}
 	if resp.StatusCode != http.StatusOK {
 		if Warnf != nil {
-			Warnf("%s/auth HTTP %d body=%q", prefix, resp.StatusCode, snippet(raw, 200))
+			Warnf("%s/auth HTTP %d body=%q", prefix, resp.StatusCode, sanitizedSnippet(raw, 200))
 		}
-		return mediaAuthResp{}, fmt.Errorf("%s auth %d: %s", prefix, resp.StatusCode, snippet(raw, 200))
+		return mediaAuthResp{}, fmt.Errorf("%s auth %d: %s", prefix, resp.StatusCode, sanitizedSnippet(raw, 200))
 	}
 	var out mediaAuthResp
 	if err := json.Unmarshal(raw, &out); err != nil {
 		if Warnf != nil {
-			Warnf("%s/auth decode failed: %v body=%q", prefix, err, snippet(raw, 200))
+			Warnf("%s/auth decode failed: %v body=%q", prefix, err, sanitizedSnippet(raw, 200))
 		}
 		return mediaAuthResp{}, fmt.Errorf("%s auth decode failed: %w", prefix, err)
 	}
@@ -147,7 +138,7 @@ func mediaGetUserDetail(prefix, serverURL, token, userID string) (mediaUserDetai
 		return mediaUserDetail{}, err
 	}
 	if Debugf != nil {
-		Debugf("%s/user GET %s (token=%v)", prefix, req.URL.String(), strings.TrimSpace(token) != "")
+		Debugf("%s/user GET %s (token=%v)", prefix, redactURLForLog(req.URL.String()), strings.TrimSpace(token) != "")
 	}
 	resp, err := doWithRetry(req)
 	if err != nil {
@@ -160,14 +151,14 @@ func mediaGetUserDetail(prefix, serverURL, token, userID string) (mediaUserDetai
 	}
 	if resp.StatusCode != 200 {
 		if Warnf != nil {
-			Warnf("%s/user HTTP %d body=%q", prefix, resp.StatusCode, snippet(raw, 200))
+			Warnf("%s/user HTTP %d body=%q", prefix, resp.StatusCode, sanitizedSnippet(raw, 200))
 		}
-		return mediaUserDetail{}, fmt.Errorf("%s user %d: %s", prefix, resp.StatusCode, snippet(raw, 200))
+		return mediaUserDetail{}, fmt.Errorf("%s user %d: %s", prefix, resp.StatusCode, sanitizedSnippet(raw, 200))
 	}
 	var out mediaUserDetail
 	if err := json.Unmarshal(raw, &out); err != nil {
 		if Warnf != nil {
-			Warnf("%s/user decode failed: %v body=%q", prefix, err, snippet(raw, 200))
+			Warnf("%s/user decode failed: %v body=%q", prefix, err, sanitizedSnippet(raw, 200))
 		}
 		return mediaUserDetail{}, fmt.Errorf("%s user decode failed: %w", prefix, err)
 	}

--- a/auth-portal/providers/jellyfin.go
+++ b/auth-portal/providers/jellyfin.go
@@ -352,7 +352,7 @@ func renderJellyfinLogin(w http.ResponseWriter, status int, prefill, message str
 func jellyfinAuthenticate(serverURL, clientID, username, password string) (mediaAuthResp, error) {
 	base := strings.TrimSuffix(serverURL, "/")
 	if Debugf != nil {
-		Debugf("jellyfin/auth start server=%s user=%q", base, username)
+		Debugf("jellyfin/auth start server=%s user=%q", redactURLForLog(base), username)
 	}
 	out, err := mediaAuthAttempt("jellyfin", base, JellyfinAppName, JellyfinAppVersion, clientID, map[string]string{
 		"Username": username,

--- a/auth-portal/providers/log_sanitize.go
+++ b/auth-portal/providers/log_sanitize.go
@@ -1,0 +1,114 @@
+package providers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+var providerSensitiveQueryKeys = map[string]struct{}{
+	"accesstoken":   {},
+	"access_token":  {},
+	"api_key":       {},
+	"apikey":        {},
+	"auth_token":    {},
+	"authorization": {},
+	"client_secret": {},
+	"code":          {},
+	"cookie":        {},
+	"idtoken":       {},
+	"id_token":      {},
+	"password":      {},
+	"refreshtoken":  {},
+	"refresh_token": {},
+	"secret":        {},
+	"state":         {},
+	"token":         {},
+	"x-plex-token":  {},
+}
+
+var providerAuthHeaderPattern = regexp.MustCompile(`(?i)(authorization["=: ]+(?:[A-Za-z]+ )?)([^",\s]+)`)
+var providerHeaderTokenPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)(x-emby-token["=: ]+)([^",\s]+)`),
+	regexp.MustCompile(`(?i)(x-mediabrowser-token["=: ]+)([^",\s]+)`),
+	regexp.MustCompile(`(?i)(x-plex-token["=: ]+)([^",\s]+)`),
+}
+var providerJSONSecretPattern = regexp.MustCompile(`(?i)("?(?:accesstoken|access_token|password|secret|client_secret|refreshtoken|refresh_token|idtoken|id_token|token|apikey|api_key|authorization)"?\s*:\s*")([^"]+)(")`)
+var providerQuerySecretPattern = regexp.MustCompile(`(?i)((?:password|secret|token|apikey|api_key|client_secret|refresh_token|access_token)=)([^&\s]+)`)
+
+func redactURLForLog(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return sanitizeLogText(raw)
+	}
+	query := parsed.Query()
+	for key := range query {
+		if _, ok := providerSensitiveQueryKeys[strings.ToLower(strings.TrimSpace(key))]; ok {
+			query.Set(key, "[REDACTED]")
+		}
+	}
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
+}
+
+func sanitizeLogText(raw string) string {
+	sanitized := strings.TrimSpace(raw)
+	if sanitized == "" {
+		return sanitized
+	}
+
+	var asJSON any
+	if json.Unmarshal([]byte(sanitized), &asJSON) == nil {
+		return marshalSanitizedJSON(asJSON)
+	}
+
+	sanitized = providerAuthHeaderPattern.ReplaceAllString(sanitized, `${1}[REDACTED]`)
+	for _, pattern := range providerHeaderTokenPatterns {
+		sanitized = pattern.ReplaceAllString(sanitized, `${1}[REDACTED]`)
+	}
+	sanitized = providerJSONSecretPattern.ReplaceAllString(sanitized, `${1}[REDACTED]${3}`)
+	sanitized = providerQuerySecretPattern.ReplaceAllString(sanitized, `${1}[REDACTED]`)
+	return sanitized
+}
+
+func marshalSanitizedJSON(value any) string {
+	sanitized := sanitizeJSONValue(value)
+	encoded, err := json.Marshal(sanitized)
+	if err != nil {
+		return "[REDACTED]"
+	}
+	return string(encoded)
+}
+
+func sanitizeJSONValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, child := range typed {
+			if _, ok := providerSensitiveQueryKeys[strings.ToLower(strings.TrimSpace(key))]; ok {
+				out[key] = "[REDACTED]"
+				continue
+			}
+			out[key] = sanitizeJSONValue(child)
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, child := range typed {
+			out = append(out, sanitizeJSONValue(child))
+		}
+		return out
+	default:
+		return typed
+	}
+}
+
+func sanitizedSnippet(raw []byte, n int) string {
+	sanitized := sanitizeLogText(string(raw))
+	if len(sanitized) > n {
+		return fmt.Sprintf("%s…", sanitized[:n])
+	}
+	return sanitized
+}

--- a/auth-portal/providers/log_sanitize_test.go
+++ b/auth-portal/providers/log_sanitize_test.go
@@ -1,0 +1,42 @@
+package providers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactURLForLogRedactsSensitiveQueryValues(t *testing.T) {
+	raw := "https://example.com/callback?code=abc123&token=tok456&client_id=public"
+	got := redactURLForLog(raw)
+	if got == raw {
+		t.Fatalf("expected URL to be sanitized")
+	}
+	if containsProviderSensitive(got, "abc123", "tok456") {
+		t.Fatalf("expected sensitive query values to be redacted, got %q", got)
+	}
+}
+
+func TestSanitizeLogTextRedactsJSONSecrets(t *testing.T) {
+	raw := `{"AccessToken":"tok123","User":{"Name":"alice"},"password":"hunter2"}`
+	got := sanitizeLogText(raw)
+	if containsProviderSensitive(got, "tok123", "hunter2") {
+		t.Fatalf("expected sensitive JSON values to be redacted, got %q", got)
+	}
+}
+
+func TestSanitizedSnippetRedactsBodySecrets(t *testing.T) {
+	raw := []byte(`{"error":"bad creds","AccessToken":"tok123","secret":"value"}`)
+	got := sanitizedSnippet(raw, 200)
+	if containsProviderSensitive(got, "tok123", "value") {
+		t.Fatalf("expected snippet to redact secrets, got %q", got)
+	}
+}
+
+func containsProviderSensitive(haystack string, needles ...string) bool {
+	for _, needle := range needles {
+		if needle != "" && strings.Contains(haystack, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/auth-portal/providers/plex.go
+++ b/auth-portal/providers/plex.go
@@ -97,11 +97,7 @@ func plexGetJSON(u, token string, out any) error {
 		return err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		s := strings.TrimSpace(string(body))
-		if len(s) > 200 {
-			s = s[:200] + "…"
-		}
-		return fmt.Errorf("plex %s -> %d: %s", u, resp.StatusCode, s)
+		return fmt.Errorf("plex %s -> %d: %s", redactURLForLog(u), resp.StatusCode, sanitizedSnippet(body, 200))
 	}
 	return json.Unmarshal(body, out)
 }
@@ -143,7 +139,7 @@ func plexCreatePin(clientID string) (plexPin, error) {
 		return plexPin{}, err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return plexPin{}, fmt.Errorf("plex pins non-2xx: %d %s", resp.StatusCode, string(body))
+		return plexPin{}, fmt.Errorf("plex pins non-2xx: %d %s", resp.StatusCode, sanitizedSnippet(body, 200))
 	}
 	var pin plexPin
 	if err := json.Unmarshal(body, &pin); err != nil {
@@ -203,7 +199,7 @@ func plexPollPinOnce(clientID string, id int) (string, plexPinPollStatus, error)
 		return "", plexPinPollRateLimited, nil
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", plexPinPollPending, fmt.Errorf("plex pin poll non-2xx: %d %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return "", plexPinPollPending, fmt.Errorf("plex pin poll non-2xx: %d %s", resp.StatusCode, sanitizedSnippet(body, 200))
 	}
 
 	var p plexPin
@@ -236,7 +232,7 @@ func plexFetchUser(token string) (plexUser, error) {
 		return plexUser{}, err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return plexUser{}, fmt.Errorf("plex user non-2xx: %d %s", resp.StatusCode, string(b))
+		return plexUser{}, fmt.Errorf("plex user non-2xx: %d %s", resp.StatusCode, sanitizedSnippet(b, 200))
 	}
 	var u plexUser
 	if err := json.Unmarshal(b, &u); err != nil {
@@ -277,7 +273,7 @@ func plexFetchResources(userToken string) ([]plexResource, error) {
 		return nil, err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("resources non-2xx: %d %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("resources non-2xx: %d %s", resp.StatusCode, sanitizedSnippet(body, 200))
 	}
 	var rs []plexResource
 	if err := json.Unmarshal(body, &rs); err != nil {

--- a/auth-portal/static/admin.js
+++ b/auth-portal/static/admin.js
@@ -1,9 +1,9 @@
 import { createConfigFormsController } from './admin/config-forms.js';
-import { createRecentChangesController } from './admin/recent-changes.js';
 import { createOAuthSectionController } from './admin/oauth-section.js';
 import { createLDAPSyncSectionController } from './admin/ldap-sync-section.js';
 import { createAccessControlSectionController } from './admin/access-control-section.js';
 import { createBackupsSectionController } from './admin/backups-section.js';
+import { createLogsSectionController } from './admin/logs-section.js';
 import { createHelpModalController } from './admin/help-modal.js';
 import { createConfigSectionController } from './admin/config-section.js';
 import { createSectionRouter } from './admin/section-router.js';
@@ -15,8 +15,6 @@ import { createAdminAPI } from './admin/admin-api.js';
   const configForm = document.getElementById('config-form');
   const configFields = document.getElementById('config-fields');
   const configEditor = document.getElementById('config-editor');
-  const historyPanel = document.getElementById('history-panel');
-  const historyList = document.getElementById('history-list');
   const panelTitle = document.getElementById('panel-title');
   const versionBadge = document.getElementById('version-badge');
   const reasonInput = document.getElementById('reason-input');
@@ -55,11 +53,6 @@ import { createAdminAPI } from './admin/admin-api.js';
   const helpModalClose = document.getElementById('help-modal-close');
   const helpModalTitle = document.getElementById('help-modal-title');
   const helpModalBody = document.getElementById('help-modal-body');
-  const recentChangesBtn = document.getElementById('recent-changes-btn');
-  const recentChangesModal = document.getElementById('recent-changes-modal');
-  const recentChangesModalClose = document.getElementById('recent-changes-modal-close');
-  const recentChangesModalTitle = document.getElementById('recent-changes-modal-title');
-  const recentChangesList = document.getElementById('recent-changes-list');
 
   const ldapSyncPanel = document.getElementById('ldap-sync-panel');
   const ldapSyncRefreshBtn = document.getElementById('ldap-sync-refresh-btn');
@@ -148,14 +141,27 @@ import { createAdminAPI } from './admin/admin-api.js';
   const backupEmptyState = document.getElementById('backup-empty');
   const backupSectionCheckboxes = Array.from(document.querySelectorAll('.backup-section-checkbox'));
   const backupFrequencyRows = Array.from(document.querySelectorAll('[data-frequency-row]'));
+
+  const logsPanel = document.getElementById('logs-panel');
+  const logsHistoryRefresh = document.getElementById('logs-history-refresh');
+  const logsHistorySummary = document.getElementById('logs-history-summary');
+  const logsFilterSection = document.getElementById('logs-filter-section');
+  const logsFilterUser = document.getElementById('logs-filter-user');
+  const logsSortOrder = document.getElementById('logs-sort-order');
+  const logsHistoryRows = document.getElementById('logs-history-rows');
+  const logsStreamStatus = document.getElementById('logs-stream-status');
+  const logsStreamInterval = document.getElementById('logs-stream-interval');
+  const logsStreamStart = document.getElementById('logs-stream-start');
+  const logsStreamPause = document.getElementById('logs-stream-pause');
+  const logsStreamRefresh = document.getElementById('logs-stream-refresh');
+  const logsStreamEmpty = document.getElementById('logs-stream-empty');
+  const logsStreamOutput = document.getElementById('logs-stream-output');
   const appTimeZone = document.body?.dataset?.appTimezone || 'UTC';
 
   if (
     !configForm ||
     !configFields ||
     !configEditor ||
-    !historyPanel ||
-    !historyList ||
     !panelTitle ||
     !versionBadge ||
     !reasonInput ||
@@ -175,6 +181,7 @@ import { createAdminAPI } from './admin/admin-api.js';
     'access-control': 'Access Control',
     backups: 'Backups',
     oauth: 'OAuth Clients',
+    logs: 'Logs',
   };
   const initialSection = 'providers';
   let sectionRouter = null;
@@ -290,10 +297,10 @@ import { createAdminAPI } from './admin/admin-api.js';
     },
   };
 
-  const nowISO = () => new Date().toISOString();
   const status = createStatusBannerController(statusBanner);
   const loadedAt = createLoadedAtController(loadedAtEl);
   const api = createAdminAPI();
+  const recordActivity = () => {};
 
   const configForms = createConfigFormsController(configFields);
 
@@ -312,32 +319,9 @@ import { createAdminAPI } from './admin/admin-api.js';
     state,
     showStatus: (message, type) => status.show(message, type),
     updateLoadedAt: () => loadedAt.update(state.loadedAt),
-    recordActivity: (...args) => recentChanges.recordLocalActivity(...args),
+    recordActivity,
   });
 
-  const recentChanges = createRecentChangesController({
-    recentChangesBtn,
-    recentChangesModal,
-    recentChangesModalClose,
-    recentChangesModalTitle,
-    recentChangesList,
-    inlineHistoryList: historyList,
-    labels,
-    isConfigSection: configSection.isConfigSection,
-    fetchHistory: async (section) => {
-      if (configSection.isConfigSection(section)) {
-        await configSection.fetchHistory(section);
-        return;
-      }
-      if (section === 'oauth') {
-        const json = await api.getOAuthHistory(25);
-        state.history.oauth = json.entries || [];
-      }
-    },
-    nowISO,
-    getCurrentSection,
-    historyState: state.history,
-  });
   const helpModalController = createHelpModalController({
     button: helpBtn,
     modal: helpModal,
@@ -378,8 +362,7 @@ import { createAdminAPI } from './admin/admin-api.js';
     detailDeleteBtn: oauthDetailDelete,
     appTimeZone,
     showStatus: (message, type) => status.show(message, type),
-    recordActivity: (section, message, reason = '') =>
-      recentChanges.recordLocalActivity(section, message, reason),
+    recordActivity,
   });
 
   const ldapSyncSection = createLDAPSyncSectionController({
@@ -427,8 +410,7 @@ import { createAdminAPI } from './admin/admin-api.js';
     testBaseCreatableEl: ldapSyncTestBaseCreatable,
     runRows: ldapSyncRunRows,
     showStatus: (message, type) => status.show(message, type),
-    recordActivity: (section, message, reason = '') =>
-      recentChanges.recordLocalActivity(section, message, reason),
+    recordActivity,
   });
 
   const accessControlSection = createAccessControlSectionController({
@@ -458,8 +440,7 @@ import { createAdminAPI } from './admin/admin-api.js';
     resetBtn: rbacBindingReset,
     saveBtn: rbacBindingSave,
     showStatus: (message, type) => status.show(message, type),
-    recordActivity: (section, message, reason = '') =>
-      recentChanges.recordLocalActivity(section, message, reason),
+    recordActivity,
   });
 
   const backupsSection = createBackupsSectionController({
@@ -485,8 +466,7 @@ import { createAdminAPI } from './admin/admin-api.js';
     frequencyRows: backupFrequencyRows,
     appTimeZone,
     showStatus: (message, type) => status.show(message, type),
-    recordActivity: (section, message, reason = '') =>
-      recentChanges.recordLocalActivity(section, message, reason),
+    recordActivity,
     onRestoreConfig: async (config) => {
       configSection.applyConfigResponse(config);
       try {
@@ -497,66 +477,74 @@ import { createAdminAPI } from './admin/admin-api.js';
       const section = getCurrentSection();
       if (configSection.isConfigSection(section)) {
         configSection.renderSection(section);
-        recentChanges.refresh(section);
       }
     },
+  });
+
+  const logsSection = createLogsSectionController({
+    api,
+    panel: logsPanel,
+    refreshBtn: logsHistoryRefresh,
+    historySummaryEl: logsHistorySummary,
+    sectionFilterEl: logsFilterSection,
+    userFilterEl: logsFilterUser,
+    sortOrderEl: logsSortOrder,
+    historyRows: logsHistoryRows,
+    streamStatusEl: logsStreamStatus,
+    streamIntervalEl: logsStreamInterval,
+    streamStartBtn: logsStreamStart,
+    streamPauseBtn: logsStreamPause,
+    streamRefreshBtn: logsStreamRefresh,
+    streamEmptyEl: logsStreamEmpty,
+    streamOutputEl: logsStreamOutput,
+    appTimeZone,
+    showStatus: (message, type) => status.show(message, type),
   });
 
   sectionRouter = createSectionRouter({
     tabs,
     configPanel: configForm,
-    historyPanel,
     oauthPanel,
     ldapSyncPanel,
     accessControlPanel,
     backupsPanel,
+    logsPanel,
     initialSection,
     isConfigSection: configSection.isConfigSection,
     hasSectionData: (section) => Boolean(state.data[section]),
     onSectionChange: async (section) => {
       helpModalController.updateButton(section);
-      recentChanges.updateButton(section);
+      if (section !== 'logs') {
+        logsSection.cleanup();
+      }
       status.clear();
     },
     onConfigSection: async (section) => {
       oauthSection.clearSecretBanner();
       await configSection.loadSection(section);
-      recentChanges.refresh(section);
     },
     onOAuthSection: async () => {
       await oauthSection.loadClients();
-      try {
-        const json = await api.getOAuthHistory(25);
-        state.history.oauth = json.entries || [];
-        recentChanges.refresh('oauth');
-      } catch (error_) {
-        console.error('OAuth history fetch failed', error_);
-      }
     },
     onLDAPSyncSection: async () => {
       oauthSection.clearSecretBanner();
       await ldapSyncSection.load();
-      try {
-        await configSection.fetchHistory('ldap-sync');
-      } catch (error_) {
-        console.error('LDAP sync history fetch failed', error_);
-      }
-      recentChanges.refresh('ldap-sync');
     },
     onAccessControlSection: async () => {
       oauthSection.clearSecretBanner();
       await accessControlSection.load();
-      recentChanges.refresh('access-control');
     },
     onBackupsSection: async () => {
       oauthSection.clearSecretBanner();
-      recentChanges.refresh('backups');
       if (backupsSection.isLoaded()) {
         backupsSection.render();
         return;
       }
       await backupsSection.load();
-      recentChanges.refresh('backups');
+    },
+    onLogsSection: async () => {
+      oauthSection.clearSecretBanner();
+      await logsSection.load();
     },
   });
 
@@ -565,10 +553,9 @@ import { createAdminAPI } from './admin/admin-api.js';
   oauthSection.bind();
   ldapSyncSection.bind();
   accessControlSection.bind();
+  logsSection.bind();
 
   helpModalController.bind();
-
-  recentChanges.bind();
 
   if (exportBtn) {
     exportBtn.addEventListener('click', () => {
@@ -588,6 +575,5 @@ import { createAdminAPI } from './admin/admin-api.js';
   sectionRouter.bind();
   sectionRouter.init();
   helpModalController.updateButton(getCurrentSection());
-  recentChanges.updateButton(getCurrentSection());
   sectionRouter.activate(getCurrentSection());
 })();

--- a/auth-portal/static/admin.js
+++ b/auth-portal/static/admin.js
@@ -148,7 +148,11 @@ import { createAdminAPI } from './admin/admin-api.js';
   const logsFilterSection = document.getElementById('logs-filter-section');
   const logsFilterUser = document.getElementById('logs-filter-user');
   const logsSortOrder = document.getElementById('logs-sort-order');
+  const logsPageSize = document.getElementById('logs-page-size');
   const logsHistoryRows = document.getElementById('logs-history-rows');
+  const logsPagePrev = document.getElementById('logs-page-prev');
+  const logsPageStatus = document.getElementById('logs-page-status');
+  const logsPageNext = document.getElementById('logs-page-next');
   const logsStreamStatus = document.getElementById('logs-stream-status');
   const logsStreamInterval = document.getElementById('logs-stream-interval');
   const logsStreamStart = document.getElementById('logs-stream-start');
@@ -489,7 +493,11 @@ import { createAdminAPI } from './admin/admin-api.js';
     sectionFilterEl: logsFilterSection,
     userFilterEl: logsFilterUser,
     sortOrderEl: logsSortOrder,
+    pageSizeEl: logsPageSize,
     historyRows: logsHistoryRows,
+    pagePrevBtn: logsPagePrev,
+    pageStatusEl: logsPageStatus,
+    pageNextBtn: logsPageNext,
     streamStatusEl: logsStreamStatus,
     streamIntervalEl: logsStreamInterval,
     streamStartBtn: logsStreamStart,

--- a/auth-portal/static/admin/admin-api.js
+++ b/auth-portal/static/admin/admin-api.js
@@ -198,6 +198,34 @@ export const createAdminAPI = () => {
     return json;
   };
 
+  const getLogsHistory = async (limit = 100) => {
+    const { res, json } = await requestJSON(
+      `/api/admin/logs/history?limit=${Number(limit) || 100}`,
+    );
+    if (!res.ok || !json?.ok) {
+      throw buildAPIError({
+        fallback: 'Logs history fetch failed',
+        status: res.status,
+        serverError: json?.error,
+      });
+    }
+    return json;
+  };
+
+  const getLogStream = async ({ cursor = 0, limit = 100 } = {}) => {
+    const { res, json } = await requestJSON(
+      `/api/admin/logs/stream?cursor=${Number(cursor) || 0}&limit=${Number(limit) || 100}`,
+    );
+    if (!res.ok || !json?.ok) {
+      throw buildAPIError({
+        fallback: 'Log stream fetch failed',
+        status: res.status,
+        serverError: json?.error,
+      });
+    }
+    return json;
+  };
+
   const getConfigPermissions = async () => {
     const { res, json } = await requestJSON('/api/admin/config/permissions');
     if (!res.ok || !json?.ok) {
@@ -400,6 +428,8 @@ export const createAdminAPI = () => {
     updateConfig,
     listOAuthClients,
     getOAuthHistory,
+    getLogsHistory,
+    getLogStream,
     listOAuthScopes,
     createOAuthClient,
     updateOAuthClient,

--- a/auth-portal/static/admin/logs-section.js
+++ b/auth-portal/static/admin/logs-section.js
@@ -8,7 +8,11 @@ export const createLogsSectionController = ({
   sectionFilterEl,
   userFilterEl,
   sortOrderEl,
+  pageSizeEl,
   historyRows,
+  pagePrevBtn,
+  pageStatusEl,
+  pageNextBtn,
   streamStatusEl,
   streamIntervalEl,
   streamStartBtn,
@@ -23,6 +27,7 @@ export const createLogsSectionController = ({
     loaded: false,
     loadingHistory: false,
     historyEntries: [],
+    currentPage: 1,
     streamActive: false,
     streamLoading: false,
     streamCursor: 0,
@@ -103,6 +108,45 @@ export const createLogsSectionController = ({
     return filtered;
   };
 
+  const getPageSize = () => {
+    const raw = String(pageSizeEl?.value || '10').toLowerCase();
+    if (raw === 'all') {
+      return 0;
+    }
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 10;
+  };
+
+  const getPaginatedHistory = () => {
+    const entries = getFilteredHistory();
+    const pageSize = getPageSize();
+    if (pageSize === 0) {
+      return {
+        entries,
+        totalEntries: entries.length,
+        pageSize,
+        totalPages: 1,
+        currentPage: 1,
+        startIndex: entries.length ? 1 : 0,
+        endIndex: entries.length,
+      };
+    }
+
+    const totalPages = Math.max(1, Math.ceil(entries.length / pageSize));
+    const currentPage = Math.min(state.currentPage, totalPages);
+    const start = (currentPage - 1) * pageSize;
+    const end = start + pageSize;
+    return {
+      entries: entries.slice(start, end),
+      totalEntries: entries.length,
+      pageSize,
+      totalPages,
+      currentPage,
+      startIndex: entries.length ? start + 1 : 0,
+      endIndex: Math.min(end, entries.length),
+    };
+  };
+
   const populateHistoryFilters = () => {
     if (sectionFilterEl) {
       const current = sectionFilterEl.value;
@@ -143,7 +187,9 @@ export const createLogsSectionController = ({
     if (!historyRows) {
       return;
     }
-    const entries = getFilteredHistory();
+    const paginated = getPaginatedHistory();
+    state.currentPage = paginated.currentPage;
+    const entries = paginated.entries;
     historyRows.innerHTML = '';
     if (!entries.length) {
       historyRows.innerHTML = '<tr><td colspan="5" class="muted">No matching log entries.</td></tr>';
@@ -161,7 +207,24 @@ export const createLogsSectionController = ({
       });
     }
     if (historySummaryEl) {
-      historySummaryEl.textContent = `${entries.length} entries shown`;
+      if (paginated.totalEntries === 0) {
+        historySummaryEl.textContent = '0 entries shown';
+      } else if (paginated.pageSize === 0) {
+        historySummaryEl.textContent = `${paginated.totalEntries} entries shown`;
+      } else {
+        historySummaryEl.textContent = `${paginated.startIndex}-${paginated.endIndex} of ${paginated.totalEntries} entries`;
+      }
+    }
+    if (pageStatusEl) {
+      pageStatusEl.textContent = paginated.pageSize === 0
+        ? 'Showing all entries'
+        : `Page ${paginated.currentPage} of ${paginated.totalPages}`;
+    }
+    if (pagePrevBtn) {
+      pagePrevBtn.disabled = paginated.pageSize === 0 || paginated.currentPage <= 1;
+    }
+    if (pageNextBtn) {
+      pageNextBtn.disabled = paginated.pageSize === 0 || paginated.currentPage >= paginated.totalPages;
     }
   };
 
@@ -217,6 +280,7 @@ export const createLogsSectionController = ({
     try {
       const json = await api.getLogsHistory(200);
       state.historyEntries = Array.isArray(json.entries) ? json.entries : [];
+      state.currentPage = 1;
       populateHistoryFilters();
       renderHistory();
       state.loaded = true;
@@ -283,8 +347,21 @@ export const createLogsSectionController = ({
     refreshBtn?.addEventListener('click', async () => {
       await fetchHistory(true);
     });
-    [sectionFilterEl, userFilterEl, sortOrderEl].filter(Boolean).forEach((input) => {
-      input.addEventListener('change', renderHistory);
+    [sectionFilterEl, userFilterEl, sortOrderEl, pageSizeEl].filter(Boolean).forEach((input) => {
+      input.addEventListener('change', () => {
+        state.currentPage = 1;
+        renderHistory();
+      });
+    });
+    pagePrevBtn?.addEventListener('click', () => {
+      if (state.currentPage > 1) {
+        state.currentPage -= 1;
+        renderHistory();
+      }
+    });
+    pageNextBtn?.addEventListener('click', () => {
+      state.currentPage += 1;
+      renderHistory();
     });
     streamStartBtn?.addEventListener('click', async () => {
       await startStream();

--- a/auth-portal/static/admin/logs-section.js
+++ b/auth-portal/static/admin/logs-section.js
@@ -1,0 +1,311 @@
+import { toUserMessage } from './admin-errors.js';
+
+export const createLogsSectionController = ({
+  api,
+  panel,
+  refreshBtn,
+  historySummaryEl,
+  sectionFilterEl,
+  userFilterEl,
+  sortOrderEl,
+  historyRows,
+  streamStatusEl,
+  streamIntervalEl,
+  streamStartBtn,
+  streamPauseBtn,
+  streamRefreshBtn,
+  streamEmptyEl,
+  streamOutputEl,
+  appTimeZone = 'UTC',
+  showStatus,
+}) => {
+  const state = {
+    loaded: false,
+    loadingHistory: false,
+    historyEntries: [],
+    streamActive: false,
+    streamLoading: false,
+    streamCursor: 0,
+    streamTimer: null,
+    streamLines: [],
+  };
+
+  const sectionLabels = {
+    providers: 'Providers',
+    security: 'Security',
+    mfa: 'MFA',
+    'app-settings': 'App Settings',
+    oauth: 'OAuth Clients',
+    'ldap-sync': 'LDAP Sync',
+    'access-control': 'Access Control',
+    backups: 'Backups',
+    logs: 'Logs',
+    rbac: 'Access Control',
+  };
+
+  const createDateFormatter = () => {
+    const options = {
+      year: 'numeric',
+      month: 'short',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      timeZoneName: 'short',
+    };
+    try {
+      return new Intl.DateTimeFormat(undefined, { ...options, timeZone: appTimeZone || 'UTC' });
+    } catch {
+      return new Intl.DateTimeFormat(undefined, options);
+    }
+  };
+
+  const dateFormatter = createDateFormatter();
+
+  const formatDate = (value) => {
+    if (!value) {
+      return '-';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+    try {
+      return dateFormatter.format(date);
+    } catch {
+      return date.toLocaleString();
+    }
+  };
+
+  const escapeHTML = (value) => String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+
+  const getFilteredHistory = () => {
+    const section = sectionFilterEl?.value || '';
+    const user = userFilterEl?.value || '';
+    const order = sortOrderEl?.value || 'desc';
+
+    const filtered = state.historyEntries.filter((entry) => {
+      const matchesSection = !section || entry.section === section;
+      const matchesUser = !user || (entry.updatedBy || '') === user;
+      return matchesSection && matchesUser;
+    });
+
+    filtered.sort((a, b) => {
+      const aTime = new Date(a.updatedAt || 0).getTime();
+      const bTime = new Date(b.updatedAt || 0).getTime();
+      return order === 'asc' ? aTime - bTime : bTime - aTime;
+    });
+    return filtered;
+  };
+
+  const populateHistoryFilters = () => {
+    if (sectionFilterEl) {
+      const current = sectionFilterEl.value;
+      const sections = Array.from(new Set(
+        state.historyEntries
+          .map((entry) => entry.section)
+          .filter(Boolean),
+      ));
+      sectionFilterEl.innerHTML = '<option value="">All tabs</option>';
+      sections.forEach((section) => {
+        const option = document.createElement('option');
+        option.value = section;
+        option.textContent = sectionLabels[section] || section;
+        sectionFilterEl.appendChild(option);
+      });
+      sectionFilterEl.value = sections.includes(current) ? current : '';
+    }
+
+    if (userFilterEl) {
+      const current = userFilterEl.value;
+      const users = Array.from(new Set(
+        state.historyEntries
+          .map((entry) => entry.updatedBy || '')
+          .filter(Boolean),
+      )).sort((a, b) => a.localeCompare(b));
+      userFilterEl.innerHTML = '<option value="">All users</option>';
+      users.forEach((user) => {
+        const option = document.createElement('option');
+        option.value = user;
+        option.textContent = user;
+        userFilterEl.appendChild(option);
+      });
+      userFilterEl.value = users.includes(current) ? current : '';
+    }
+  };
+
+  const renderHistory = () => {
+    if (!historyRows) {
+      return;
+    }
+    const entries = getFilteredHistory();
+    historyRows.innerHTML = '';
+    if (!entries.length) {
+      historyRows.innerHTML = '<tr><td colspan="5" class="muted">No matching log entries.</td></tr>';
+    } else {
+      entries.forEach((entry) => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td>${escapeHTML(formatDate(entry.updatedAt))}</td>
+          <td>${escapeHTML(entry.label || sectionLabels[entry.section] || entry.section || '-')}</td>
+          <td>${escapeHTML(entry.updatedBy || 'system')}</td>
+          <td>${escapeHTML(entry.action || '-')}</td>
+          <td>${escapeHTML(entry.subject ? `${entry.subject}${entry.details ? ' - ' : ''}` : '')}${escapeHTML(entry.details || '-')}</td>
+        `;
+        historyRows.appendChild(tr);
+      });
+    }
+    if (historySummaryEl) {
+      historySummaryEl.textContent = `${entries.length} entries shown`;
+    }
+  };
+
+  const renderStream = () => {
+    if (!streamOutputEl || !streamEmptyEl) {
+      return;
+    }
+    const hasLines = state.streamLines.length > 0;
+    streamOutputEl.hidden = !hasLines;
+    streamEmptyEl.hidden = hasLines;
+    if (hasLines) {
+      streamOutputEl.textContent = state.streamLines
+        .map((entry) => `[${formatDate(entry.timestamp)}] ${entry.message}`)
+        .join('\n');
+      streamOutputEl.scrollTop = streamOutputEl.scrollHeight;
+    }
+    if (streamStatusEl) {
+      if (state.streamActive) {
+        const seconds = Math.max(1, Math.round((Number(streamIntervalEl?.value) || 5000) / 1000));
+        streamStatusEl.textContent = `Streaming every ${seconds} seconds.`;
+      } else if (hasLines) {
+        streamStatusEl.textContent = 'Stream paused.';
+      } else {
+        streamStatusEl.textContent = 'Stream is off.';
+      }
+    }
+    if (streamStartBtn) {
+      streamStartBtn.disabled = state.streamActive;
+    }
+    if (streamPauseBtn) {
+      streamPauseBtn.disabled = !state.streamActive;
+    }
+    if (streamRefreshBtn) {
+      streamRefreshBtn.disabled = state.streamActive || state.streamLoading;
+    }
+    if (streamIntervalEl) {
+      streamIntervalEl.disabled = state.streamActive;
+    }
+  };
+
+  const stopStreamTimer = () => {
+    if (state.streamTimer) {
+      clearInterval(state.streamTimer);
+      state.streamTimer = null;
+    }
+  };
+
+  const fetchHistory = async (announce = false) => {
+    if (state.loadingHistory) {
+      return;
+    }
+    state.loadingHistory = true;
+    try {
+      const json = await api.getLogsHistory(200);
+      state.historyEntries = Array.isArray(json.entries) ? json.entries : [];
+      populateHistoryFilters();
+      renderHistory();
+      state.loaded = true;
+      if (announce) {
+        showStatus('Logs refreshed.', 'success');
+      }
+    } catch (err) {
+      showStatus(toUserMessage(err, 'Logs fetch failed'), 'error');
+    } finally {
+      state.loadingHistory = false;
+    }
+  };
+
+  const fetchStream = async () => {
+    if (state.streamLoading) {
+      return;
+    }
+    state.streamLoading = true;
+    try {
+      const json = await api.getLogStream({ cursor: state.streamCursor, limit: 100 });
+      const entries = Array.isArray(json.entries) ? json.entries : [];
+      if (entries.length) {
+        state.streamLines = state.streamLines.concat(entries).slice(-300);
+      }
+      state.streamCursor = Number(json.cursor) || state.streamCursor;
+      renderStream();
+    } catch (err) {
+      showStatus(toUserMessage(err, 'Log stream fetch failed'), 'error');
+      stopStreamTimer();
+      state.streamActive = false;
+      renderStream();
+    } finally {
+      state.streamLoading = false;
+    }
+  };
+
+  const startStream = async () => {
+    if (state.streamActive) {
+      return;
+    }
+    state.streamActive = true;
+    renderStream();
+    await fetchStream();
+    stopStreamTimer();
+    state.streamTimer = globalThis.setInterval(() => {
+      void fetchStream();
+    }, Number(streamIntervalEl?.value) || 5000);
+  };
+
+  const pauseStream = () => {
+    state.streamActive = false;
+    stopStreamTimer();
+    renderStream();
+  };
+
+  const refreshStreamOnce = async () => {
+    if (state.streamActive) {
+      return;
+    }
+    await fetchStream();
+  };
+
+  const bind = () => {
+    refreshBtn?.addEventListener('click', async () => {
+      await fetchHistory(true);
+    });
+    [sectionFilterEl, userFilterEl, sortOrderEl].filter(Boolean).forEach((input) => {
+      input.addEventListener('change', renderHistory);
+    });
+    streamStartBtn?.addEventListener('click', async () => {
+      await startStream();
+    });
+    streamPauseBtn?.addEventListener('click', () => {
+      pauseStream();
+    });
+    streamRefreshBtn?.addEventListener('click', async () => {
+      await refreshStreamOnce();
+    });
+  };
+
+  return {
+    bind,
+    load: async () => {
+      await fetchHistory(false);
+      renderStream();
+    },
+    cleanup: () => {
+      pauseStream();
+    },
+    isLoaded: () => state.loaded,
+  };
+};

--- a/auth-portal/static/admin/section-router.js
+++ b/auth-portal/static/admin/section-router.js
@@ -1,11 +1,11 @@
 export const createSectionRouter = ({
   tabs,
   configPanel,
-  historyPanel,
   oauthPanel,
   ldapSyncPanel,
   accessControlPanel,
   backupsPanel,
+  logsPanel,
   initialSection = 'providers',
   isConfigSection,
   hasSectionData,
@@ -15,15 +15,17 @@ export const createSectionRouter = ({
   onLDAPSyncSection,
   onAccessControlSection,
   onBackupsSection,
+  onLogsSection,
 }) => {
   let currentSection = initialSection;
 
   const panelVisibility = {
-    config: { config: false, history: false, oauth: true, ldapSync: true, accessControl: true, backups: true },
-    oauth: { config: true, history: false, oauth: false, ldapSync: true, accessControl: true, backups: true },
-    'ldap-sync': { config: true, history: false, oauth: true, ldapSync: false, accessControl: true, backups: true },
-    'access-control': { config: true, history: false, oauth: true, ldapSync: true, accessControl: false, backups: true },
-    backups: { config: true, history: false, oauth: true, ldapSync: true, accessControl: true, backups: false },
+    config: { config: false, oauth: true, ldapSync: true, accessControl: true, backups: true, logs: true },
+    oauth: { config: true, oauth: false, ldapSync: true, accessControl: true, backups: true, logs: true },
+    'ldap-sync': { config: true, oauth: true, ldapSync: false, accessControl: true, backups: true, logs: true },
+    'access-control': { config: true, oauth: true, ldapSync: true, accessControl: false, backups: true, logs: true },
+    backups: { config: true, oauth: true, ldapSync: true, accessControl: true, backups: false, logs: true },
+    logs: { config: true, oauth: true, ldapSync: true, accessControl: true, backups: true, logs: false },
   };
 
   const setActiveTab = () => {
@@ -36,9 +38,6 @@ export const createSectionRouter = ({
     if (configPanel) {
       configPanel.hidden = visibility.config;
     }
-    if (historyPanel) {
-      historyPanel.hidden = visibility.history;
-    }
     if (oauthPanel) {
       oauthPanel.hidden = visibility.oauth;
     }
@@ -50,6 +49,9 @@ export const createSectionRouter = ({
     }
     if (backupsPanel) {
       backupsPanel.hidden = visibility.backups;
+    }
+    if (logsPanel) {
+      logsPanel.hidden = visibility.logs;
     }
   };
 
@@ -85,6 +87,7 @@ export const createSectionRouter = ({
       'ldap-sync': { panel: ldapSyncPanel, handler: onLDAPSyncSection },
       'access-control': { panel: accessControlPanel, handler: onAccessControlSection },
       backups: { panel: backupsPanel, handler: onBackupsSection },
+      logs: { panel: logsPanel, handler: onLogsSection },
     };
     const special = specialSections[section];
     if (!special?.panel || typeof special.handler !== 'function') {

--- a/auth-portal/static/admin/smoke-test.mjs
+++ b/auth-portal/static/admin/smoke-test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { createSectionRouter } from './section-router.js';
 import { createConfigSectionController } from './config-section.js';
 import { createHelpModalController } from './help-modal.js';
-import { createRecentChangesController } from './recent-changes.js';
+import { createLogsSectionController } from './logs-section.js';
 import { createOAuthSectionController } from './oauth-section.js';
 import { createLDAPSyncSectionController } from './ldap-sync-section.js';
 import { createBackupsSectionController } from './backups-section.js';
@@ -160,7 +160,7 @@ const runConfigSmoke = async () => {
   assert.equal(recorded, 'providers:Configuration saved');
 };
 
-const runHelpAndRecentSmoke = () => {
+const runHelpAndLogsSmoke = () => {
   const helpBtn = makeEl();
   const help = createHelpModalController({
     button: helpBtn,
@@ -178,22 +178,32 @@ const runHelpAndRecentSmoke = () => {
   help.updateButton('oauth');
   assert.equal(helpBtn.hidden, true);
 
-  const historyState = { providers: [] };
-  const recent = createRecentChangesController({
-    recentChangesBtn: makeEl(),
-    recentChangesModal: makeEl(),
-    recentChangesModalClose: makeEl(),
-    recentChangesModalTitle: makeEl(),
-    recentChangesList: { ...makeEl(), innerHTML: '', appendChild() {} },
-    labels: { providers: 'Providers' },
-    isConfigSection: () => false,
-    fetchHistory: async () => {},
-    nowISO: () => '2026-03-08T00:00:00Z',
-    getCurrentSection: () => 'providers',
-    historyState,
+  const logs = createLogsSectionController({
+    api: {
+      async getLogsHistory() {
+        return { entries: [] };
+      },
+      async getLogStream() {
+        return { cursor: 0, entries: [] };
+      },
+    },
+    panel: makeEl(),
+    refreshBtn: makeEl(),
+    historySummaryEl: makeEl(),
+    sectionFilterEl: { ...makeEl(), value: '', innerHTML: '', appendChild() {}, addEventListener() {} },
+    userFilterEl: { ...makeEl(), value: '', innerHTML: '', appendChild() {}, addEventListener() {} },
+    sortOrderEl: { ...makeEl(), value: 'desc', addEventListener() {} },
+    historyRows: { ...makeEl(), innerHTML: '', appendChild() {} },
+    streamStatusEl: makeEl(),
+    streamIntervalEl: { ...makeEl(), value: '5000' },
+    streamStartBtn: makeEl(),
+    streamPauseBtn: makeEl(),
+    streamRefreshBtn: makeEl(),
+    streamEmptyEl: makeEl(),
+    streamOutputEl: { ...makeEl(), hidden: true, scrollTop: 0, scrollHeight: 0 },
+    showStatus() {},
   });
-  recent.recordLocalActivity('providers', 'Changed');
-  assert.equal(historyState.providers.length, 1);
+  assert.equal(typeof logs.load, 'function');
 };
 
 const runConstructionSmoke = () => {
@@ -201,6 +211,8 @@ const runConstructionSmoke = () => {
   const methods = [
     'getConfig',
     'getConfigHistory',
+    'getLogsHistory',
+    'getLogStream',
     'updateConfig',
     'listOAuthClients',
     'createOAuthClient',
@@ -317,7 +329,7 @@ const runConstructionSmoke = () => {
 const run = async () => {
   await runRouterSmoke();
   await runConfigSmoke();
-  runHelpAndRecentSmoke();
+  runHelpAndLogsSmoke();
   runConstructionSmoke();
   console.log('admin smoke tests passed');
 };

--- a/auth-portal/static/styles.css
+++ b/auth-portal/static/styles.css
@@ -361,6 +361,7 @@ a:hover{opacity:.9}
 .logs-filters,.logs-stream-controls{display:grid;gap:1rem;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));align-items:end;}
 .logs-filters .form-row,.logs-stream-controls .form-row{display:flex;flex-direction:column;gap:.4rem;}
 .logs-filters select,.logs-stream-controls select{background:#0b1220;border:1px solid var(--border);border-radius:10px;color:var(--text);padding:.6rem .85rem;}
+.logs-pagination{display:flex;align-items:center;justify-content:flex-end;gap:.75rem;flex-wrap:wrap;}
 .logs-stream-actions{display:flex;gap:.75rem;align-items:center;flex-wrap:wrap;}
 .logs-table-wrapper{margin-top:0;}
 .logs-table{min-width:880px;}

--- a/auth-portal/static/styles.css
+++ b/auth-portal/static/styles.css
@@ -278,7 +278,7 @@ a:hover{opacity:.9}
 .admin-tab{text-align:left;justify-content:flex-start;}
 .admin-tab.active{background:rgba(245,158,11,.16);border-color:var(--brand);}
 .admin-content{flex:1;padding:2rem;overflow:auto;}
-.admin-panels{display:grid;gap:1.5rem;grid-template-columns:minmax(0,1fr) 320px;align-items:start;}
+.admin-panels{display:grid;gap:1.5rem;grid-template-columns:minmax(0,1fr);align-items:start;}
 .panel{background:var(--card);border:1px solid var(--border);border-radius:16px;padding:1.5rem;box-shadow:0 8px 28px rgba(0,0,0,.28);}
 .panel-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem;}
 .panel-header-actions{display:flex;align-items:center;gap:.75rem;}
@@ -354,10 +354,17 @@ a:hover{opacity:.9}
 .config-tools{display:flex;gap:.75rem;margin-bottom:1rem;flex-wrap:wrap;}
 .config-tools .ghost-btn{min-width:110px;}
 .config-tools input[type="file"]{display:none;}
-.history-panel{max-height:100%;overflow:auto;}
-.history-list{list-style:none;margin:0;padding:1rem;font-family:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;font-size:.85rem;background:#0b1220;border:1px solid var(--border);border-radius:12px;max-height:340px;overflow:auto;}
-.history-list li+li{margin-top:.75rem;padding-top:.75rem;border-top:1px solid #1e293b;}
-.recent-changes-list{max-height:50vh;}
+.logs-section{display:flex;flex-direction:column;gap:1rem;padding:1rem 0;}
+.logs-section+.logs-section{border-top:1px solid var(--border);}
+.logs-section-header{display:flex;align-items:center;justify-content:space-between;gap:1rem;flex-wrap:wrap;}
+.logs-section-header h3{margin:0;}
+.logs-filters,.logs-stream-controls{display:grid;gap:1rem;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));align-items:end;}
+.logs-filters .form-row,.logs-stream-controls .form-row{display:flex;flex-direction:column;gap:.4rem;}
+.logs-filters select,.logs-stream-controls select{background:#0b1220;border:1px solid var(--border);border-radius:10px;color:var(--text);padding:.6rem .85rem;}
+.logs-stream-actions{display:flex;gap:.75rem;align-items:center;flex-wrap:wrap;}
+.logs-table-wrapper{margin-top:0;}
+.logs-table{min-width:880px;}
+.logs-stream-output{margin:0;background:#0b1220;border:1px solid var(--border);border-radius:12px;padding:1rem;min-height:320px;max-height:520px;overflow:auto;font-family:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;font-size:.85rem;line-height:1.45;white-space:pre-wrap;word-break:break-word;}
 .secret-banner{display:none;padding:.75rem 1rem;margin:0 0 1rem;border-radius:10px;border:1px dashed rgba(59,130,246,.65);background:rgba(59,130,246,.18);color:#dbeafe;font-family:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;word-break:break-all;}
 .secret-banner.show{display:block;}
 .ghost-btn,.primary-btn,.success-btn,.danger-btn{padding:.65rem 1.2rem;border-radius:10px;font-weight:600;line-height:1;display:inline-flex;align-items:center;justify-content:center;gap:.4rem;cursor:pointer;transition:transform .2s ease,opacity .2s ease,background .2s ease,border-color .2s ease;color:var(--text);border:1px solid transparent;}
@@ -499,7 +506,6 @@ a:hover{opacity:.9}
   .admin-nav{flex-direction:row;width:auto;border-right:none;border-bottom:1px solid var(--border);padding:1rem;gap:.5rem;}
   .admin-tab{flex:1;text-align:center;}
   .admin-panels{grid-template-columns:1fr;}
-  .history-panel{max-height:none;}
   .ldap-sync-header-actions{justify-content:flex-start;}
   .ldap-sync-card-emphasis{grid-column:span 1;}
   .ldap-sync-section-head{flex-direction:column;}

--- a/auth-portal/templates/admin.html
+++ b/auth-portal/templates/admin.html
@@ -28,6 +28,7 @@
             <button type="button" class="admin-tab ghost-btn" data-section="ldap-sync">LDAP Sync</button>
             <button type="button" class="admin-tab ghost-btn" data-section="access-control">Access Control</button>
             <button type="button" class="admin-tab ghost-btn" data-section="backups">Backups</button>
+            <button type="button" class="admin-tab ghost-btn" data-section="logs">Logs</button>
         </aside>
 
         <section class="admin-content">
@@ -556,16 +557,83 @@
                     </div>
                 </div>
 
-                <div id="history-panel" class="panel history-panel">
+                <div id="logs-panel" class="panel" hidden>
                     <div class="panel-header">
-                        <h3>Recent Changes</h3>
+                        <h2>Logs</h2>
                         <div class="panel-header-actions">
-                            <button type="button" id="recent-changes-btn" class="ghost-btn">View All</button>
+                            <button type="button" id="logs-history-refresh" class="ghost-btn">Refresh</button>
                         </div>
                     </div>
-                    <ul id="history-list" class="history-list">
-                        <li>Loading.</li>
-                    </ul>
+                    <p class="panel-helper">Review admin audit activity across the console and inspect the live application log stream when needed.</p>
+
+                    <section class="logs-section">
+                        <div class="logs-section-header">
+                            <h3>Recent Changes</h3>
+                            <span id="logs-history-summary" class="muted">Loading.</span>
+                        </div>
+                        <div class="logs-filters">
+                            <div class="form-row">
+                                <label for="logs-filter-section">Tab</label>
+                                <select id="logs-filter-section">
+                                    <option value="">All tabs</option>
+                                </select>
+                            </div>
+                            <div class="form-row">
+                                <label for="logs-filter-user">User</label>
+                                <select id="logs-filter-user">
+                                    <option value="">All users</option>
+                                </select>
+                            </div>
+                            <div class="form-row">
+                                <label for="logs-sort-order">Sort</label>
+                                <select id="logs-sort-order">
+                                    <option value="desc">Newest first</option>
+                                    <option value="asc">Oldest first</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="backup-table-wrapper logs-table-wrapper">
+                            <table class="backup-table logs-table">
+                                <thead>
+                                    <tr>
+                                        <th>Changed</th>
+                                        <th>Tab</th>
+                                        <th>User</th>
+                                        <th>Action</th>
+                                        <th>Details</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="logs-history-rows">
+                                    <tr><td colspan="5" class="muted">Loading recent changes.</td></tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </section>
+
+                    <section class="logs-section">
+                        <div class="logs-section-header">
+                            <h3>Log Stream</h3>
+                            <span id="logs-stream-status" class="muted">Stream is off.</span>
+                        </div>
+                        <div class="logs-stream-controls">
+                            <div class="form-row">
+                                <label for="logs-stream-interval">Auto refresh</label>
+                                <select id="logs-stream-interval">
+                                    <option value="5000">Every 5 seconds</option>
+                                    <option value="10000">Every 10 seconds</option>
+                                    <option value="30000">Every 30 seconds</option>
+                                    <option value="60000">Every 60 seconds</option>
+                                </select>
+                            </div>
+                            <div class="logs-stream-actions">
+                                <button type="button" id="logs-stream-start" class="success-btn">Start</button>
+                                <button type="button" id="logs-stream-pause" class="ghost-btn">Pause</button>
+                                <button type="button" id="logs-stream-refresh" class="ghost-btn">Refresh</button>
+                            </div>
+                        </div>
+                        <div id="logs-stream-empty" class="muted">Log stream is off. Start the stream to load entries.</div>
+                        <pre id="logs-stream-output" class="logs-stream-output" hidden></pre>
+                    </section>
                 </div>
             </div>
         </section>
@@ -577,19 +645,6 @@
             <button type="button" id="help-modal-close" class="icon-btn close-btn" aria-label="Close help" title="Close">×</button>
             <h3 id="help-modal-title">Configuration Help</h3>
             <div id="help-modal-body" class="modal-body"></div>
-        </div>
-    </dialog>
-
-    <dialog id="recent-changes-modal" class="modal" hidden aria-labelledby="recent-changes-modal-title">
-        <div class="modal-backdrop" data-recent-close></div>
-        <div class="modal-dialog">
-            <button type="button" id="recent-changes-modal-close" class="icon-btn close-btn" aria-label="Close recent changes" title="Close">×</button>
-            <h3 id="recent-changes-modal-title">Recent Changes</h3>
-            <div class="modal-body">
-                <ul id="recent-changes-list" class="history-list recent-changes-list">
-                    <li>Loading.</li>
-                </ul>
-            </div>
         </div>
     </dialog>
 

--- a/auth-portal/templates/admin.html
+++ b/auth-portal/templates/admin.html
@@ -591,6 +591,15 @@
                                     <option value="asc">Oldest first</option>
                                 </select>
                             </div>
+                            <div class="form-row">
+                                <label for="logs-page-size">Rows</label>
+                                <select id="logs-page-size">
+                                    <option value="10" selected>10</option>
+                                    <option value="25">25</option>
+                                    <option value="50">50</option>
+                                    <option value="all">All</option>
+                                </select>
+                            </div>
                         </div>
                         <div class="backup-table-wrapper logs-table-wrapper">
                             <table class="backup-table logs-table">
@@ -607,6 +616,11 @@
                                     <tr><td colspan="5" class="muted">Loading recent changes.</td></tr>
                                 </tbody>
                             </table>
+                        </div>
+                        <div class="logs-pagination">
+                            <button type="button" id="logs-page-prev" class="ghost-btn">Previous</button>
+                            <span id="logs-page-status" class="muted">Page 1 of 1</span>
+                            <button type="button" id="logs-page-next" class="ghost-btn">Next</button>
                         </div>
                     </section>
 


### PR DESCRIPTION
- Add a dedicated Logs tab to the admin console that replaces the old per-tab recent changes view with a consolidated audit table and live log stream.

- The new logs table aggregates recent changes across admin sections, supports filtering by tab and user, and allows sorting by change date for easier review. The live stream panel adds admin controls for starting, pausing, manual refresh, and configurable auto-refresh, with streaming disabled by default.

- On the backend, add log history and stream endpoints, persist RBAC and backup audit events, and wire the admin UI to the new APIs. Also update routing, styles, and smoke coverage for the new logs workflow.

- Redact sensitive values from request and provider logs. Did not find any sensitive values in logs to begin with, but wanted to add hardening and redaction around logging sensitive values now that it is centralized to an admin UI tab. Better safe than sorry.

- Paginate logs history table with configurable page size.