### PR TITLE
chore(security): replace gitleaks with trufflehog and git-secrets

### DIFF
--- a/.github/workflows/build-and-publish-auth-portal.yml
+++ b/.github/workflows/build-and-publish-auth-portal.yml
@@ -36,12 +36,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Secret scan (Gitleaks)
-        uses: gitleaks/gitleaks-action@44c470ffc35caa8b1eb3e8012ca53c2f9bea4eb5
+      - name: Secret scan (TruffleHog)
+        uses: trufflesecurity/trufflehog@v3.94.3
         with:
-          args: detect --source . --no-git --redact
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          extra_args: --results=verified,unknown
 
       - name: Set up Go cache (optional)
         uses: actions/cache@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,0 @@
-repos:
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.9.0
-    hooks:
-      - id: gitleaks
-        args: [--staged, --redact]

--- a/MAKEFILE
+++ b/MAKEFILE
@@ -8,6 +8,7 @@ help:
 	@echo "make build        # go build"
 	@echo "make test         # go test"
 	@echo "make smoke-admin  # admin JS smoke tests"
+	@echo "make install-git-secrets # install git-secrets hooks for this repo"
 	@echo "make docker       # local docker build (amd64)"
 	@echo "make tag          # create signed git tag v$(VERSION)"
 	@echo "make release      # push tag to trigger CI release"
@@ -31,6 +32,11 @@ smoke-admin:
 docker:
 	@echo "==> docker build $(IMAGE):$(SHA)"
 	docker build -t $(IMAGE):$(SHA) .
+
+.PHONY: install-git-secrets
+install-git-secrets:
+	@echo "==> install git-secrets hooks"
+	./scripts/install-git-secrets-hooks.sh
 
 .PHONY: tag
 tag:

--- a/README.md
+++ b/README.md
@@ -743,7 +743,8 @@ DEBUG plex: resources match via machine id
 Automated security checks run on this project:
 
 - Syft SBOM + Grype: SBOM generated from the built image; Grype scans that SBOM.
-- Gitleaks: secret scanning on every push/PR; local hook below to keep commits clean.
+- TruffleHog: secret scanning on every push/PR in CI/CD.
+- git-secrets: local pre-commit and commit-message guardrail to catch credentials before they land in git history.
 - GitHub CodeQL: static analysis for code-level vulnerabilities in every PR and on main.
 - Trivy: container and dependency scans to catch OS and library CVEs in our images.
 - Docker Scout: image-level vulnerability insights for each commit/tag, including base image and layer analysis.
@@ -751,15 +752,24 @@ Automated security checks run on this project:
 
 If you spot an issue or have questions about these scans, please open an issue or reach out.
 
-### Local secret scanning (pre-commit)
+### Local secret scanning (git-secrets)
 
-Run Gitleaks locally before pushing:
+Install `git-secrets`, then bootstrap the repo hooks:
 
 ```bash
-pip install pre-commit
-pre-commit install
-pre-commit run --all-files
+brew install git-secrets
+./scripts/install-git-secrets-hooks.sh
+git secrets --scan-history
 ```
+
+On Windows PowerShell:
+
+```powershell
+.\scripts\install-git-secrets-hooks.ps1
+git secrets --scan-history
+```
+
+The bootstrap scripts install `git-secrets` hooks for this repository and register AWS patterns plus a small set of generic credential patterns for passwords, tokens, API keys, and private keys.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,7 +46,8 @@ AuthPortal layers AES-GCM token sealing, HTTP-only JWT sessions, RBAC authorizat
 Automated security checks run on this project:
 
 - Syft SBOM + Grype: SBOM generated from the built image; Grype scans that SBOM.
-- Gitleaks: secret scanning on every push/PR; local hook below to keep commits clean.
+- TruffleHog: secret scanning on every push/PR in CI/CD.
+- git-secrets: local pre-commit and commit-message guardrail to catch credentials before they land in git history.
 - GitHub CodeQL: static analysis for code-level vulnerabilities in every PR and on main.
 - Trivy: container and dependency scans to catch OS and library CVEs in our images.
 - Docker Scout: image-level vulnerability insights for each commit/tag, including base image and layer analysis.

--- a/scripts/install-git-secrets-hooks.ps1
+++ b/scripts/install-git-secrets-hooks.ps1
@@ -1,0 +1,21 @@
+$ErrorActionPreference = 'Stop'
+
+if (-not (Get-Command git-secrets -ErrorAction SilentlyContinue)) {
+    Write-Error "git-secrets is not installed or not on PATH. Install it first, then rerun this script."
+}
+
+$repoRoot = (git rev-parse --show-toplevel).Trim()
+Set-Location $repoRoot
+
+git secrets --install -f
+git secrets --register-aws
+
+git secrets --add --literal '-----BEGIN OPENSSH PRIVATE KEY-----'
+git secrets --add --literal '-----BEGIN PRIVATE KEY-----'
+git secrets --add --literal '-----BEGIN RSA PRIVATE KEY-----'
+git secrets --add '(api[_-]?key|token|secret|client[_-]?secret|password|passwd|pwd|session[_-]?secret)[[:space:]]*[:=][[:space:]]*["''`][^"''`[:space:]]{8,}["''`]'
+git secrets --add 'gh[pousr]_[A-Za-z0-9_]{20,255}'
+git secrets --add 'github_pat_[A-Za-z0-9_]{20,255}'
+git secrets --add 'xox[baprs]-[A-Za-z0-9-]{10,200}'
+
+Write-Host "git-secrets hooks installed for $repoRoot"

--- a/scripts/install-git-secrets-hooks.sh
+++ b/scripts/install-git-secrets-hooks.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v git-secrets >/dev/null 2>&1; then
+  echo "git-secrets is not installed or not on PATH." >&2
+  echo "Install it first, then rerun this script." >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+git secrets --install -f
+git secrets --register-aws
+
+git secrets --add --literal '-----BEGIN OPENSSH PRIVATE KEY-----'
+git secrets --add --literal '-----BEGIN PRIVATE KEY-----'
+git secrets --add --literal '-----BEGIN RSA PRIVATE KEY-----'
+git secrets --add '(api[_-]?key|token|secret|client[_-]?secret|password|passwd|pwd|session[_-]?secret)[[:space:]]*[:=][[:space:]]*['"'"'`][^'"'"'`[:space:]]{8,}['"'"'`]'
+git secrets --add 'gh[pousr]_[A-Za-z0-9_]{20,255}'
+git secrets --add 'github_pat_[A-Za-z0-9_]{20,255}'
+git secrets --add 'xox[baprs]-[A-Za-z0-9-]{10,200}'
+
+echo "git-secrets hooks installed for $repo_root"


### PR DESCRIPTION
## Summary

Replace `gitleaks` with `trufflehog` for CI/CD secret scanning and switch local secret guardrails from `pre-commit`/`gitleaks` to `git-secrets`.

## Changes

- replace the GitHub Actions secret scan step with `trufflesecurity/trufflehog@v3.94.3`
- remove the legacy `.pre-commit-config.yaml` `gitleaks` hook config
- add repo bootstrap scripts for `git-secrets` on Bash and PowerShell
- add a `make install-git-secrets` helper target
- update README and SECURITY docs to describe the new scanning workflow

## Why

- stop relying on `gitleaks`
- keep CI/CD secret scanning in place with `trufflehog`
- keep a local pre-commit guardrail with `git-secrets`
- make local setup explicit and repeatable across Unix-like shells and Windows PowerShell

## Validation

- verified the new hook bootstrap scripts parse cleanly in Bash and PowerShell
- verified no `gitleaks` references remain in the repository
