### PR TITLE
fix(oidc): allow CORS for OpenID discovery

### DIFF
--- a/.github/workflows/build-and-publish-auth-portal.yml
+++ b/.github/workflows/build-and-publish-auth-portal.yml
@@ -44,12 +44,12 @@ jobs:
           persist-credentials: false
 
       - name: Secret scan (TruffleHog)
-        uses: trufflesecurity/trufflehog@47e7b7cd74f578e1e3145d48f669f22fd1330ca6 # v3.94.3
+        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26 # v3.95.2
         with:
           extra_args: --results=verified,unknown
 
       - name: Set up Go cache (optional)
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/go-build
@@ -202,7 +202,7 @@ jobs:
 
       - name: Scan image with Trivy
         if: github.event_name != 'pull_request'
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           version: v0.69.3
           scan-type: image

--- a/auth-portal/go.mod
+++ b/auth-portal/go.mod
@@ -16,7 +16,7 @@ require (
 require golang.org/x/crypto v0.45.0
 
 require (
-	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
+	github.com/Azure/go-ntlmssp v0.1.1 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.5 // indirect
 	github.com/google/uuid v1.3.1 // indirect
 )

--- a/auth-portal/go.sum
+++ b/auth-portal/go.sum
@@ -1,5 +1,7 @@
 github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+s7s0MwaRv9igoPqLRdzOLzw/8Xvq8=
 github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
+github.com/Azure/go-ntlmssp v0.1.1 h1:l+FM/EEMb0U9QZE7mKNEDw5Mu3mFiaa2GKOoTSsNDPw=
+github.com/Azure/go-ntlmssp v0.1.1/go.mod h1:NYqdhxd/8aAct/s4qSYZEerdPuH1liG2/X9DiVTbhpk=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/alexbrainman/sspi v0.0.0-20210105120005-909beea2cc74 h1:Kk6a4nehpJ3UuJRqlA3JxYxBZEqCeOmATOvrbT4p9RA=

--- a/auth-portal/main.go
+++ b/auth-portal/main.go
@@ -395,7 +395,7 @@ func registerEnrollmentRoutes(r *mux.Router, lim routeLimiters) {
 }
 
 func registerOIDCRoutes(r *mux.Router) {
-	r.HandleFunc("/.well-known/openid-configuration", oidcDiscoveryHandler).Methods("GET")
+	r.HandleFunc("/.well-known/openid-configuration", oidcDiscoveryHandler).Methods("GET", "OPTIONS")
 	r.HandleFunc("/oidc/jwks.json", oidcJWKSHandler).Methods("GET")
 	r.Handle("/oidc/authorize", authMiddleware(http.HandlerFunc(oidcAuthorizeHandler))).Methods("GET")
 	r.Handle("/oidc/authorize/decision", authMiddleware(requireSameOrigin(http.HandlerFunc(oidcAuthorizeDecisionHandler)))).Methods("POST")

--- a/auth-portal/oidc_handlers.go
+++ b/auth-portal/oidc_handlers.go
@@ -22,13 +22,18 @@ import (
 )
 
 const (
-	oidcContentTypeJSON = "application/json"
-	oidcHeaderContent   = "Content-Type"
-	oidcHeaderCache     = "Cache-Control"
-	oidcHeaderPragma    = "Pragma"
-	oidcHeaderWWWAuth   = "WWW-Authenticate"
-	oidcCacheNoStore    = "no-store"
-	oidcCacheNoPragma   = "no-cache"
+	oidcContentTypeJSON    = "application/json"
+	oidcHeaderContent      = "Content-Type"
+	oidcHeaderCache        = "Cache-Control"
+	oidcHeaderPragma       = "Pragma"
+	oidcHeaderWWWAuth      = "WWW-Authenticate"
+	oidcHeaderAllowOrigin  = "Access-Control-Allow-Origin"
+	oidcHeaderAllowMethods = "Access-Control-Allow-Methods"
+	oidcHeaderAllowHeaders = "Access-Control-Allow-Headers"
+	oidcHeaderMaxAge       = "Access-Control-Max-Age"
+	oidcHeaderVary         = "Vary"
+	oidcCacheNoStore       = "no-store"
+	oidcCacheNoPragma      = "no-cache"
 
 	errUserNotFound          = "user not found"
 	errCodeVerifierMismatch  = "code_verifier mismatch"
@@ -56,7 +61,13 @@ const (
 	oidcErrDescInvalidRedirectURI  = "invalid redirect_uri"
 )
 
-func oidcDiscoveryHandler(w http.ResponseWriter, _ *http.Request) {
+func oidcDiscoveryHandler(w http.ResponseWriter, r *http.Request) {
+	applyOIDCDiscoveryCORS(w, r)
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	issuer := oidcIssuer()
 	base := strings.TrimRight(issuer, "/")
 	scopesSupported := supportedOIDCScopes()
@@ -109,6 +120,84 @@ func oidcDiscoveryHandler(w http.ResponseWriter, _ *http.Request) {
 
 	w.Header().Set(oidcHeaderContent, oidcContentTypeJSON)
 	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func applyOIDCDiscoveryCORS(w http.ResponseWriter, r *http.Request) {
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if origin == "" {
+		return
+	}
+	allowedOrigin := allowedOIDCDiscoveryCORSOrigin(r.Context(), origin)
+	if allowedOrigin == "" {
+		return
+	}
+	w.Header().Set(oidcHeaderAllowOrigin, allowedOrigin)
+	w.Header().Set(oidcHeaderAllowMethods, "GET, OPTIONS")
+	w.Header().Set(oidcHeaderAllowHeaders, "Accept, Content-Type")
+	w.Header().Set(oidcHeaderMaxAge, "3600")
+	w.Header().Add(oidcHeaderVary, "Origin")
+}
+
+func allowedOIDCDiscoveryCORSOrigin(ctx context.Context, origin string) string {
+	normalized := normalizedCORSOrigin(origin)
+	if normalized == "" {
+		return ""
+	}
+	if oidcDiscoveryOriginRegistered(ctx, normalized) {
+		return normalized
+	}
+	return "*"
+}
+
+func oidcDiscoveryOriginRegistered(ctx context.Context, origin string) bool {
+	if oauthService.DB == nil {
+		return false
+	}
+	clients, err := oauthService.ListClients(ctx)
+	if err != nil {
+		log.Printf("oidc discovery: oauth client lookup failed for CORS origin %q: %v", origin, err)
+		return false
+	}
+	for _, client := range clients {
+		for _, redirectURI := range client.RedirectURIs {
+			if redirectURIOrigin(redirectURI) == origin {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func redirectURIOrigin(raw string) string {
+	normalized := normalizeRedirectValue(raw)
+	if normalized == "" {
+		return ""
+	}
+	u, err := url.Parse(normalized)
+	if err != nil || !u.IsAbs() {
+		return ""
+	}
+	return normalizedURLOrigin(u)
+}
+
+func normalizedCORSOrigin(raw string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || !u.IsAbs() || u.Host == "" || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+		return ""
+	}
+	return normalizedURLOrigin(u)
+}
+
+func normalizedURLOrigin(u *url.URL) string {
+	scheme := strings.ToLower(strings.TrimSpace(u.Scheme))
+	if scheme != "http" && scheme != "https" {
+		return ""
+	}
+	host := strings.ToLower(strings.TrimSpace(u.Host))
+	if host == "" {
+		return ""
+	}
+	return scheme + "://" + host
 }
 
 func oidcJWKSHandler(w http.ResponseWriter, _ *http.Request) {

--- a/auth-portal/oidc_handlers_test.go
+++ b/auth-portal/oidc_handlers_test.go
@@ -27,10 +27,10 @@ const (
 	unexpectedErrorCodeFmt   = "unexpected error code: got %q want %q"
 	unexpectedDescriptionFmt = "unexpected description: got %q want %q"
 
-	testClientID      = "client-123"
-	testClientName    = "Test App"
-	testCallbackURL   = "https://example.com/callback"
-	testTokenPath     = "/oidc/token"
+	testClientID          = "client-123"
+	testClientName        = "Test App"
+	testCallbackURL       = "https://example.com/callback"
+	testTokenPath         = "/oidc/token"
 	testHeaderContentType = "Content-Type"
 	mimeFormURLEnc        = "application/x-www-form-urlencoded"
 )
@@ -88,6 +88,104 @@ func TestFinishAuthorizeFlowSuccess(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf(unmetExpectationsFmt, err)
+	}
+}
+
+func TestOIDCDiscoveryHandlerAllowsRegisteredRedirectOrigin(t *testing.T) {
+	testDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf(sqlMockErrFmt, err)
+	}
+	defer testDB.Close()
+
+	originalService := oauthService
+	originalDB := db
+	defer func() {
+		oauthService = originalService
+		db = originalDB
+	}()
+
+	oauthService = oauth.Service{DB: testDB}
+	db = testDB
+
+	now := time.Now()
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT client_id, client_secret, name, redirect_uris, scopes, grant_types, response_types, created_at, updated_at
+  FROM oauth_clients
+ ORDER BY created_at ASC
+`)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"client_id",
+			"client_secret",
+			"name",
+			"redirect_uris",
+			"scopes",
+			"grant_types",
+			"response_types",
+			"created_at",
+			"updated_at",
+		}).AddRow(
+			testClientID,
+			"",
+			testClientName,
+			pq.StringArray{"https://app.example.com/callback"},
+			pq.StringArray{"openid"},
+			pq.StringArray{"authorization_code", "refresh_token"},
+			pq.StringArray{"code"},
+			now,
+			now,
+		))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT name, COALESCE(description, '')
+  FROM permissions
+ ORDER BY name
+`)).
+		WillReturnRows(sqlmock.NewRows([]string{"name", "description"}).
+			AddRow("profile", "Profile").
+			AddRow("email", "Email"))
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	req.Header.Set("Origin", "https://app.example.com")
+
+	rr := httptest.NewRecorder()
+	oidcDiscoveryHandler(rr, req)
+
+	resp := rr.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf(unexpectedStatusFmt, resp.StatusCode, http.StatusOK)
+	}
+	if got := resp.Header.Get(oidcHeaderAllowOrigin); got != "https://app.example.com" {
+		t.Fatalf("unexpected CORS origin: got %q want %q", got, "https://app.example.com")
+	}
+	if got := resp.Header.Get(oidcHeaderVary); got != "Origin" {
+		t.Fatalf("unexpected Vary header: got %q want %q", got, "Origin")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf(unmetExpectationsFmt, err)
+	}
+}
+
+func TestOIDCDiscoveryHandlerHandlesCORSPreflight(t *testing.T) {
+	originalService := oauthService
+	defer func() { oauthService = originalService }()
+
+	oauthService = oauth.Service{}
+
+	req := httptest.NewRequest(http.MethodOptions, "/.well-known/openid-configuration", nil)
+	req.Header.Set("Origin", "https://unknown.example.com")
+
+	rr := httptest.NewRecorder()
+	oidcDiscoveryHandler(rr, req)
+
+	resp := rr.Result()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf(unexpectedStatusFmt, resp.StatusCode, http.StatusNoContent)
+	}
+	if got := resp.Header.Get(oidcHeaderAllowOrigin); got != "*" {
+		t.Fatalf("unexpected CORS origin: got %q want %q", got, "*")
+	}
+	if got := resp.Header.Get(oidcHeaderAllowMethods); !strings.Contains(got, http.MethodGet) || !strings.Contains(got, http.MethodOptions) {
+		t.Fatalf("unexpected CORS methods: %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes CORS failures when browser-based applications fetch `/.well-known/openid-configuration` from a different origin. Also bumped a few packages based on CVE recommendations.

Found in issue #120.

## Changes

- Adds `OPTIONS` handling for `/.well-known/openid-configuration`
- Emits CORS headers for OpenID discovery requests with an `Origin` header
- Echoes the requesting origin when it matches a configured OAuth client redirect origin
- Falls back to `Access-Control-Allow-Origin: *` for the public discovery document
- Adds tests for registered-origin CORS and preflight handling

## Dependency Bumps

 - bump github.com/Azure/go-ntlmssp to v0.1.1
 - bump trufflesecurity/trufflehog from 3.94.3 to 3.95.2
 - bump aquasecurity/trivy-action from 0.35.0 to 0.36.0
 - bump actions/cache from 5.0.4 to 5.0.5