### PR TITLE
chore: bump golang to 1.26.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/modomofn/auth-portal.svg)](https://hub.docker.com/r/modomofn/auth-portal)
 [![Docker Image Size](https://img.shields.io/docker/image-size/modomofn/auth-portal/latest)](https://hub.docker.com/r/modomofn/auth-portal)
-[![Go Version](https://img.shields.io/badge/Go-1.25.5%2B-00ADD8?logo=go)](https://go.dev/)
+[![Go Version](https://img.shields.io/badge/Go-1.26.3%2B-00ADD8?logo=go)](https://go.dev/)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL3.0-green.svg)](https://github.com/modom-ofn/auth-portal?tab=GPL-3.0-1-ov-file#readme)
 [![Vibe Coded](https://img.shields.io/badge/Vibe_Coded-OpenAI_Codex-purple)](https://developers.openai.com/codex/windows)
 
@@ -555,8 +555,8 @@ CREATE TABLE IF NOT EXISTS pins (
 
 ## Build & Images
 
-- Go: `1.25.5` on `alpine:3.21`.
-- Builder installs `git` + CA certs, runs `go mod download` then `go mod tidy -compat=1.25`, builds with:
+- Go: `1.26.3` on `alpine:3.23`.
+- Builder installs `git` + CA certs, runs `go mod download` then `go mod tidy -compat=1.26`, builds with:
     - `-v -x` (verbose), `-buildvcs=false` (avoid VCS scans), `-trimpath`, `-ldflags "-s -w"`.
 - Runtime: `alpine:3.21`, installs CA certs + tzdata, runs as non-root `uid 10001`.
 
@@ -734,7 +734,7 @@ GPL-3.0  https://opensource.org/license/lgpl-3-0
 
 ## Upgrade Guide (from < v2.0.2)
 
-1) Rebuild or pull `modomofn/auth-portal:v2.0.3` so you pick up Go 1.25.5 plus the patched OpenSSL 3.3.5 / BusyBox layers.
+1) Rebuild or pull `modomofn/auth-portal:v2.0.3` so you pick up Go 1.26.3 plus the patched OpenSSL 3.3.5 / BusyBox layers.
 2) Set `SESSION_COOKIE_DOMAIN` to the host you serve AuthPortal from (e.g., `auth.example.com`) so session + pending-MFA cookies survive redirect flows.
 3) Decide on MFA posture:
    - Leave `MFA_ENABLE=1` to let users enroll.

--- a/auth-portal/Dockerfile
+++ b/auth-portal/Dockerfile
@@ -1,5 +1,5 @@
 # ---- builder ----
-FROM golang:1.25.9-alpine3.22 AS build
+FROM golang:1.26.3-alpine3.23 AS build
 WORKDIR /src
 
 # Tools needed for fetching modules over HTTPS
@@ -20,7 +20,7 @@ COPY configstore ./configstore
 COPY health ./health
 COPY static ./static
 COPY templates ./templates
-RUN go mod tidy -compat=1.25
+RUN go mod tidy -compat=1.26
 
 # 3) Build static binary (verbose, no VCS scan)
 RUN mkdir -p /out && \

--- a/auth-portal/go.mod
+++ b/auth-portal/go.mod
@@ -1,8 +1,8 @@
 module auth-portal
 
-go 1.25
+go 1.26
 
-toolchain go1.25.9
+toolchain go1.26.3
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
Bumped Go/stdlib target to 1.26.3 in:

- auth-portal/go.mod (line 3): go 1.26, toolchain go1.26.3
- auth-portal/Dockerfile (line 2): golang:1.26.3-alpine3.23, go mod tidy -compat=1.26
- README.md (line 5): Go badge/build notes updated to 1.26.3