### PR TITLE
Add custom portal background image controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # AuthPortal Changelog
 
+## Unreleased
+
+### Added
+- Added App Settings controls for a custom portal background URL and display mode (`span`, `fit`, `centered`, `original`, `stretch`, or `tile`). A custom background URL overrides only `portalBackgroundColor`; other portal styling colors continue to apply.
+
+### Fixed
+- Prevented the authorized portal page from showing transient vertical overflow when moving the mouse by letting the portal layout reserve footer space and keeping the animated grain layer out of scrollable layout.
+
 ## v2.0.5 - 2026-04-08
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ APP_TIMEZONE=UTC
 TZ=UTC
 
 # 32-byte base64 key (e.g., openssl rand -base64 32) (Do Not Reuse Example Below)
-DATA_KEY=5Z3UMPcF9BBkpB2SkuoXqYfGWKn1eXzpMdR8EyMV8dY=
+DATA_KEY=generate-your-own-key
 
 # Admin bootstrap (comma-separated username:email pairs)
 ADMIN_BOOTSTRAP_USERS=admin:admin@example.com

--- a/README.md
+++ b/README.md
@@ -720,9 +720,11 @@ DEBUG plex: resources match via machine id
 
 ## Customization
 
-- **Logo:** in `templates/login.html`, swap the inline SVG for your logo.  
-- **Colors & button:** tweak in `static/styles.css` (`--brand` etc.).
-- **Authorized / Unauthorized pages:** edit `templates/portal_authorized.html` and `templates/portal_unauthorized.html`
+- **Branding and portal styling:** use **Admin -> App Settings** to set the end-user portal app name, logo URL, background color, modal color, title color, body text color, and optional custom background image.
+- **Custom background image:** set `portalBackgroundUrl` to a relative path such as `/static/portal-background.jpg` or an absolute `http(s)` URL. When this is set, it overrides only `portalBackgroundColor`; modal, title, body text, and service button colors continue to apply.
+- **Background display mode:** set `portalBackgroundMode` to `span`, `fit`, `centered`, `original`, `stretch`, or `tile`. `span` is the default and fills the viewport while cropping as needed; `fit` keeps the whole image visible; `centered` uses the image's natural size centered in the viewport; `original` uses natural size from the top-left; `stretch` forces the image to the viewport; `tile` repeats it.
+- **Environment defaults:** first-run/default values can be supplied with `PORTAL_APP_NAME`, `PORTAL_LOGO_URL`, `PORTAL_BACKGROUND_COLOR`, `PORTAL_BACKGROUND_URL`, `PORTAL_BACKGROUND_MODE`, `PORTAL_MODAL_COLOR`, `PORTAL_TITLE_COLOR`, and `PORTAL_BODY_TEXT_COLOR`. Once App Settings are saved in Postgres, manage ongoing changes through the admin UI or `/api/admin/config/app-settings`.
+- **Authorized / Unauthorized page copy:** edit the text fields in **Admin -> App Settings -> Portal Config**. The copy fields support `{{username}}`, `{{providerName}}`, and `{{appName}}`.
 
 ---
 

--- a/auth-portal-full-stack-dev.env
+++ b/auth-portal-full-stack-dev.env
@@ -34,7 +34,7 @@ FORCE_SECURE_COOKIE=0
 FORCE_HSTS=0
 
 # 32-byte base64 key (e.g., openssl rand -base64 32) (Do Not Reuse Example Below)
-DATA_KEY=5Z3UMPcF9BBkpB2SkuoXqYfGWKn1eXzpMdR8EyMV8dY=
+DATA_KEY=generate-your-own-key
 
 # Admin bootstrap (comma-separated username:email pairs)
 ADMIN_BOOTSTRAP_USERS=admin:admin@example.com

--- a/auth-portal-full-stack-dev.env
+++ b/auth-portal-full-stack-dev.env
@@ -21,6 +21,17 @@ MFA_ISSUER=AuthPortal
 LOGIN_EXTRA_LINK_URL=/some-internal-app
 LOGIN_EXTRA_LINK_TEXT=Open Internal App
 
+# Portal branding and styling defaults (optional; Admin -> App Settings can override)
+PORTAL_APP_NAME=AuthPortal
+PORTAL_LOGO_URL=/static/authportal-logo.svg
+PORTAL_BACKGROUND_COLOR=#0b1020
+PORTAL_BACKGROUND_URL=
+# Background mode: span | fit | centered | original | stretch | tile
+PORTAL_BACKGROUND_MODE=span
+PORTAL_MODAL_COLOR=#111827
+PORTAL_TITLE_COLOR=#e5e7eb
+PORTAL_BODY_TEXT_COLOR=#94a3b8
+
 # Unauthorized page "Request Access" mailto link
 UNAUTH_REQUEST_EMAIL=support@example.com
 UNAUTH_REQUEST_SUBJECT=AuthPortal Access Request

--- a/auth-portal/admin_handlers.go
+++ b/auth-portal/admin_handlers.go
@@ -949,6 +949,8 @@ func normalizeAppSettingsConfig(cfg *AppSettingsConfig) {
 	cfg.LoginExtraLinkText = strings.TrimSpace(firstNonEmpty(cfg.LoginExtraLinkText, defaults.LoginExtraLinkText))
 	cfg.PortalAppName = strings.TrimSpace(firstNonEmpty(cfg.PortalAppName, defaults.PortalAppName))
 	cfg.PortalLogoURL = strings.TrimSpace(firstNonEmpty(cfg.PortalLogoURL, defaults.PortalLogoURL))
+	cfg.PortalBackgroundURL = strings.TrimSpace(firstNonEmpty(cfg.PortalBackgroundURL, defaults.PortalBackgroundURL))
+	cfg.PortalBackgroundMode = normalizePortalBackgroundMode(firstNonEmpty(cfg.PortalBackgroundMode, defaults.PortalBackgroundMode))
 	cfg.LoginBodyText = strings.TrimSpace(firstNonEmpty(cfg.LoginBodyText, defaults.LoginBodyText))
 	cfg.AuthorizedTitleText = strings.TrimSpace(firstNonEmpty(cfg.AuthorizedTitleText, defaults.AuthorizedTitleText))
 	cfg.AuthorizedBodyText = strings.TrimSpace(firstNonEmpty(cfg.AuthorizedBodyText, defaults.AuthorizedBodyText))
@@ -1057,6 +1059,21 @@ func validateOptionalLogoLink(raw string) error {
 	return nil
 }
 
+func validateOptionalBackgroundLink(raw string) error {
+	link := strings.TrimSpace(raw)
+	if link != "" && !isValidPortalLinkURL(link) {
+		return errors.New("portal background URL must be a relative path or absolute URL")
+	}
+	return nil
+}
+
+func validatePortalBackgroundMode(raw string) error {
+	if !isValidPortalBackgroundMode(raw) {
+		return errors.New("portal background mode must be one of span, fit, centered, original, stretch, or tile")
+	}
+	return nil
+}
+
 func validateOptionalRequestEmail(raw string) error {
 	email := strings.TrimSpace(raw)
 	if email == "" {
@@ -1112,6 +1129,8 @@ func validateAppSettingsConfig(cfg AppSettingsConfig) error {
 	optionalChecks := []func() error{
 		func() error { return validateOptionalPortalLink(cfg.LoginExtraLinkURL) },
 		func() error { return validateOptionalLogoLink(cfg.PortalLogoURL) },
+		func() error { return validateOptionalBackgroundLink(cfg.PortalBackgroundURL) },
+		func() error { return validatePortalBackgroundMode(cfg.PortalBackgroundMode) },
 		func() error { return validateOptionalRequestEmail(cfg.UnauthRequestEmail) },
 		func() error { return validateOptionalPortalColor(cfg.PortalBackgroundColor, "portal background color") },
 		func() error { return validateOptionalPortalColor(cfg.PortalModalColor, "portal modal color") },

--- a/auth-portal/admin_handlers_test.go
+++ b/auth-portal/admin_handlers_test.go
@@ -61,6 +61,8 @@ func TestValidateAppSettingsConfig(t *testing.T) {
 		LoginExtraLinkText:    "Docs",
 		PortalAppName:         "North Ridge Portal",
 		PortalLogoURL:         "/static/north-ridge-logo.png",
+		PortalBackgroundURL:   "/static/north-ridge-background.jpg",
+		PortalBackgroundMode:  "fit",
 		LoginBodyText:         "Sign in with your {{providerName}} account to continue.",
 		AuthorizedTitleText:   "Welcome, {{username}}",
 		AuthorizedBodyText:    "Your access to {{appName}} is active.",
@@ -127,6 +129,57 @@ func TestValidateAppSettingsConfig(t *testing.T) {
 	normalizeAppSettingsConfig(&invalidLogo)
 	if validateAppSettingsConfig(invalidLogo) == nil {
 		t.Fatalf("expected validation error for invalid portal logo URL")
+	}
+
+	invalidBackground := AppSettingsConfig{
+		PortalBackgroundURL: "javascript:alert(1)",
+	}
+	normalizeAppSettingsConfig(&invalidBackground)
+	if validateAppSettingsConfig(invalidBackground) == nil {
+		t.Fatalf("expected validation error for invalid portal background URL")
+	}
+
+	invalidBackgroundMode := AppSettingsConfig{
+		PortalBackgroundMode: "sideways",
+	}
+	normalizeAppSettingsConfig(&invalidBackgroundMode)
+	if validateAppSettingsConfig(invalidBackgroundMode) == nil {
+		t.Fatalf("expected validation error for invalid portal background mode")
+	}
+}
+
+func TestPortalBackgroundPresentationUsesCustomURL(t *testing.T) {
+	previous := runtimeConfigValue.Load()
+	defer func() {
+		if previous != nil {
+			runtimeConfigValue.Store(previous)
+			return
+		}
+		runtimeConfigValue.Store(RuntimeConfig{AppSettings: defaultAppSettingsConfig()})
+	}()
+
+	runtimeConfigValue.Store(RuntimeConfig{
+		AppSettings: AppSettingsConfig{
+			PortalBackgroundColor: "#ffffff",
+			PortalBackgroundURL:   "/static/custom-background.jpg",
+			PortalBackgroundMode:  "fit",
+		},
+	})
+
+	color, bgURL, mode := portalBackgroundPresentation()
+	if bgURL != "/static/custom-background.jpg" {
+		t.Fatalf("expected custom background URL, got %q", bgURL)
+	}
+	if mode != "bg-mode-image bg-image-fit" {
+		t.Fatalf("expected image mode, got %q", mode)
+	}
+	if color != "#0b1020" {
+		t.Fatalf("expected neutral fallback color for image mode, got %q", color)
+	}
+
+	style := string(portalBackgroundStyle(color, bgURL))
+	if style != `--portal-bg-color: #0b1020; --portal-bg-image: url("/static/custom-background.jpg");` {
+		t.Fatalf("unexpected background style: %q", style)
 	}
 }
 

--- a/auth-portal/handlers.go
+++ b/auth-portal/handlers.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"html/template"
 	"log"
 	"net/http"
 	"net/mail"
@@ -120,13 +121,72 @@ func serviceButtonTextColor(color string) string {
 	return readableTextForHex(color)
 }
 
-func portalBackgroundPresentation() (heroColor, modeClass string) {
+func portalBackgroundPresentation() (heroColor, heroURL, modeClass string) {
+	bgMode := normalizePortalBackgroundMode(currentRuntimeConfig().AppSettings.PortalBackgroundMode)
+	if !isValidPortalBackgroundMode(bgMode) {
+		bgMode = "span"
+	}
+	heroURL = sanitizeDisplayURL(currentRuntimeConfig().AppSettings.PortalBackgroundURL)
+	if heroURL != "" {
+		return "#0b1020", heroURL, "bg-mode-image bg-image-" + bgMode
+	}
 	heroColor = sanitizeHexColor(currentRuntimeConfig().AppSettings.PortalBackgroundColor)
 	if heroColor == "" {
 		heroColor = "#0b1020"
 	}
 	modeClass = "bg-mode-solid"
-	return heroColor, modeClass
+	return heroColor, "", modeClass
+}
+
+func normalizePortalBackgroundMode(raw string) string {
+	mode := strings.ToLower(strings.TrimSpace(raw))
+	switch mode {
+	case "", "span", "cover":
+		return "span"
+	case "fit", "contain":
+		return "fit"
+	case "center", "centered":
+		return "centered"
+	case "original", "actual":
+		return "original"
+	case "stretch":
+		return "stretch"
+	case "tile", "tiled":
+		return "tile"
+	default:
+		return mode
+	}
+}
+
+func isValidPortalBackgroundMode(raw string) bool {
+	switch normalizePortalBackgroundMode(raw) {
+	case "span", "fit", "centered", "original", "stretch", "tile":
+		return true
+	default:
+		return false
+	}
+}
+
+func portalBackgroundStyle(heroColor, heroURL string) template.CSS {
+	if heroURL != "" {
+		return template.CSS(`--portal-bg-color: #0b1020; --portal-bg-image: url("` + cssQuotedURL(heroURL) + `");`)
+	}
+	color := sanitizeHexColor(heroColor)
+	if color == "" {
+		color = "#0b1020"
+	}
+	return template.CSS("--portal-bg-color: " + color + ";")
+}
+
+func cssQuotedURL(raw string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\"`,
+		"\n", "",
+		"\r", "",
+		"\f", "",
+	)
+	return replacer.Replace(raw)
 }
 
 func portalModalPresentation() (cardColor, modeClass string) {
@@ -271,7 +331,8 @@ func sanitizeMailAddress(raw string) string {
 func loginPageHandler(w http.ResponseWriter, r *http.Request) {
 	key, name := providerUI()
 	extraURL, extraText := extraLink()
-	heroColor, modeClass := portalBackgroundPresentation()
+	heroColor, heroURL, modeClass := portalBackgroundPresentation()
+	heroStyle := portalBackgroundStyle(heroColor, heroURL)
 	cardColor, cardMode := portalModalPresentation()
 	titleColor := portalTitleColor()
 	bodyTextColor := portalBodyTextColor()
@@ -293,6 +354,7 @@ func loginPageHandler(w http.ResponseWriter, r *http.Request) {
 			"ExtraLinkURL":        extraURL,
 			"ExtraLinkText":       extraText,
 			"HeroBackgroundColor": heroColor,
+			"HeroBackgroundStyle": heroStyle,
 			"HeroBackgroundMode":  modeClass,
 			"PortalCardColor":     cardColor,
 			"PortalCardMode":      cardMode,
@@ -320,6 +382,7 @@ func loginPageHandler(w http.ResponseWriter, r *http.Request) {
 			"ExtraLinkURL":        extraURL,
 			"ExtraLinkText":       extraText,
 			"HeroBackgroundColor": heroColor,
+			"HeroBackgroundStyle": heroStyle,
 			"HeroBackgroundMode":  modeClass,
 			"PortalCardColor":     cardColor,
 			"PortalCardMode":      cardMode,
@@ -344,6 +407,7 @@ func loginPageHandler(w http.ResponseWriter, r *http.Request) {
 			"ExtraLinkURL":        extraURL,
 			"ExtraLinkText":       extraText,
 			"HeroBackgroundColor": heroColor,
+			"HeroBackgroundStyle": heroStyle,
 			"HeroBackgroundMode":  modeClass,
 			"PortalCardColor":     cardColor,
 			"PortalCardMode":      cardMode,
@@ -368,6 +432,7 @@ func loginPageHandler(w http.ResponseWriter, r *http.Request) {
 				"ExtraLinkURL":        extraURL,
 				"ExtraLinkText":       extraText,
 				"HeroBackgroundColor": heroColor,
+				"HeroBackgroundStyle": heroStyle,
 				"HeroBackgroundMode":  modeClass,
 				"PortalCardColor":     cardColor,
 				"PortalCardMode":      cardMode,
@@ -382,6 +447,7 @@ func loginPageHandler(w http.ResponseWriter, r *http.Request) {
 			"ExtraLinkURL":        extraURL,
 			"ExtraLinkText":       extraText,
 			"HeroBackgroundColor": heroColor,
+			"HeroBackgroundStyle": heroStyle,
 			"HeroBackgroundMode":  modeClass,
 			"PortalCardColor":     cardColor,
 			"PortalCardMode":      cardMode,
@@ -579,7 +645,8 @@ func homeHandler(w http.ResponseWriter, r *http.Request) {
 	// Use env-cased name for display
 	_, providerDisplay := providerUI()
 	extraURL, extraText := extraLink()
-	heroColor, modeClass := portalBackgroundPresentation()
+	heroColor, heroURL, modeClass := portalBackgroundPresentation()
+	heroStyle := portalBackgroundStyle(heroColor, heroURL)
 	cardColor, cardMode := portalModalPresentation()
 	titleColor := portalTitleColor()
 	bodyTextColor := portalBodyTextColor()
@@ -605,6 +672,7 @@ func homeHandler(w http.ResponseWriter, r *http.Request) {
 			"ExtraLinkText":       extraText,
 			"ServiceLinks":        serviceLinks,
 			"HeroBackgroundColor": heroColor,
+			"HeroBackgroundStyle": heroStyle,
 			"HeroBackgroundMode":  modeClass,
 			"PortalCardColor":     cardColor,
 			"PortalCardMode":      cardMode,
@@ -634,6 +702,7 @@ func homeHandler(w http.ResponseWriter, r *http.Request) {
 		"RequestSubject":      subj,
 		"RequestSubjectQP":    subjQP,
 		"HeroBackgroundColor": heroColor,
+		"HeroBackgroundStyle": heroStyle,
 		"HeroBackgroundMode":  modeClass,
 		"PortalCardColor":     cardColor,
 		"PortalCardMode":      cardMode,
@@ -673,12 +742,14 @@ func mfaChallengePage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	heroColor, heroMode := portalBackgroundPresentation()
+	heroColor, heroURL, heroMode := portalBackgroundPresentation()
+	heroStyle := portalBackgroundStyle(heroColor, heroURL)
 	cardColor, cardMode := portalModalPresentation()
 	render(w, "mfa_challenge.html", map[string]any{
 		"Username":            strings.TrimSpace(claims.Username),
 		"Issuer":              mfaIssuer,
 		"HeroBackgroundColor": heroColor,
+		"HeroBackgroundStyle": heroStyle,
 		"HeroBackgroundMode":  heroMode,
 		"PortalCardColor":     cardColor,
 		"PortalCardMode":      cardMode,
@@ -690,12 +761,14 @@ func mfaEnrollPage(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, providers.PostAuthRedirectHome, http.StatusFound)
 		return
 	}
-	heroColor, heroMode := portalBackgroundPresentation()
+	heroColor, heroURL, heroMode := portalBackgroundPresentation()
+	heroStyle := portalBackgroundStyle(heroColor, heroURL)
 	cardColor, cardMode := portalModalPresentation()
 	render(w, "mfa_enroll.html", map[string]any{
 		"Username":            uname,
 		"Issuer":              mfaIssuer,
 		"HeroBackgroundColor": heroColor,
+		"HeroBackgroundStyle": heroStyle,
 		"HeroBackgroundMode":  heroMode,
 		"PortalCardColor":     cardColor,
 		"PortalCardMode":      cardMode,

--- a/auth-portal/runtime_config.go
+++ b/auth-portal/runtime_config.go
@@ -69,6 +69,8 @@ type AppSettingsConfig struct {
 	LoginExtraLinkText    string           `json:"loginExtraLinkText"`
 	PortalAppName         string           `json:"portalAppName,omitempty"`
 	PortalLogoURL         string           `json:"portalLogoUrl,omitempty"`
+	PortalBackgroundURL   string           `json:"portalBackgroundUrl,omitempty"`
+	PortalBackgroundMode  string           `json:"portalBackgroundMode,omitempty"`
 	LoginBodyText         string           `json:"loginBodyText,omitempty"`
 	AuthorizedTitleText   string           `json:"authorizedTitleText,omitempty"`
 	AuthorizedBodyText    string           `json:"authorizedBodyText,omitempty"`
@@ -223,6 +225,8 @@ func defaultAppSettingsConfig() AppSettingsConfig {
 		LoginExtraLinkText:    strings.TrimSpace(os.Getenv("LOGIN_EXTRA_LINK_TEXT")),
 		PortalAppName:         strings.TrimSpace(os.Getenv("PORTAL_APP_NAME")),
 		PortalLogoURL:         strings.TrimSpace(os.Getenv("PORTAL_LOGO_URL")),
+		PortalBackgroundURL:   strings.TrimSpace(os.Getenv("PORTAL_BACKGROUND_URL")),
+		PortalBackgroundMode:  strings.TrimSpace(os.Getenv("PORTAL_BACKGROUND_MODE")),
 		LoginBodyText:         strings.TrimSpace(os.Getenv("LOGIN_BODY_TEXT")),
 		AuthorizedTitleText:   strings.TrimSpace(os.Getenv("AUTHORIZED_TITLE_TEXT")),
 		AuthorizedBodyText:    strings.TrimSpace(os.Getenv("AUTHORIZED_BODY_TEXT")),
@@ -458,6 +462,8 @@ func applyRuntimeConfig(cfg RuntimeConfig) {
 	cfg.AppSettings.LoginExtraLinkText = loginExtraLinkText
 	cfg.AppSettings.PortalAppName = strings.TrimSpace(firstNonEmpty(cfg.AppSettings.PortalAppName, defaults.AppSettings.PortalAppName))
 	cfg.AppSettings.PortalLogoURL = strings.TrimSpace(firstNonEmpty(cfg.AppSettings.PortalLogoURL, defaults.AppSettings.PortalLogoURL))
+	cfg.AppSettings.PortalBackgroundURL = strings.TrimSpace(firstNonEmpty(cfg.AppSettings.PortalBackgroundURL, defaults.AppSettings.PortalBackgroundURL))
+	cfg.AppSettings.PortalBackgroundMode = normalizePortalBackgroundMode(firstNonEmpty(cfg.AppSettings.PortalBackgroundMode, defaults.AppSettings.PortalBackgroundMode))
 	cfg.AppSettings.LoginBodyText = strings.TrimSpace(firstNonEmpty(cfg.AppSettings.LoginBodyText, defaults.AppSettings.LoginBodyText))
 	cfg.AppSettings.AuthorizedTitleText = strings.TrimSpace(firstNonEmpty(cfg.AppSettings.AuthorizedTitleText, defaults.AppSettings.AuthorizedTitleText))
 	cfg.AppSettings.AuthorizedBodyText = strings.TrimSpace(firstNonEmpty(cfg.AppSettings.AuthorizedBodyText, defaults.AppSettings.AuthorizedBodyText))

--- a/auth-portal/static/admin.js
+++ b/auth-portal/static/admin.js
@@ -387,7 +387,9 @@ const initializeSidebarToggle = () => {
           <li><code>disableFooter</code> hides the footer on end-user pages only.</li>
           <li><code>loginExtraLinkUrl</code> and <code>loginExtraLinkText</code> add an optional button to the authorized portal header. Leave either blank to fall back to the shipped defaults.</li>
           <li><code>serviceLinks</code> defines zero or more button-style links shown to authorized users. Each entry needs a <code>name</code> and <code>url</code>; optional <code>color</code> accepts <code>#RRGGBB</code>.</li>
-          <li><code>portalBackgroundColor</code> controls login/home page background color.</li>
+          <li><code>portalBackgroundColor</code> controls login/home page background color unless <code>portalBackgroundUrl</code> is set.</li>
+          <li><code>portalBackgroundUrl</code> changes the login/home page background image and overrides only <code>portalBackgroundColor</code>.</li>
+          <li><code>portalBackgroundMode</code> controls how the background image is placed: <code>span</code>, <code>fit</code>, <code>centered</code>, <code>original</code>, <code>stretch</code>, or <code>tile</code>.</li>
           <li><code>portalModalColor</code> controls authorized/unauthorized modal panel color.</li>
           <li><code>portalTitleColor</code> and <code>portalBodyTextColor</code> control end-user page heading and body copy colors.</li>
           <li><code>unauthRequestEmail</code> and <code>unauthRequestSubject</code> power the mailto link shown on the unauthorized page. Provide a valid email address so users can reach you; empty values revert to defaults.</li>
@@ -408,6 +410,8 @@ const initializeSidebarToggle = () => {
     { "name": "Audiobookshelf", "url": "https://audiobooks.example.com", "color": "#1d4ed8" }
   ],
   "portalBackgroundColor": "#0b1020",
+  "portalBackgroundUrl": "/static/north-ridge-background.jpg",
+  "portalBackgroundMode": "span",
   "portalModalColor": "#111827",
   "portalTitleColor": "#e5e7eb",
   "portalBodyTextColor": "#94a3b8",

--- a/auth-portal/static/admin/config-forms.js
+++ b/auth-portal/static/admin/config-forms.js
@@ -456,6 +456,26 @@ export const createConfigFormsController = (configFields) => {
           </div>
         </div>
       </div>
+      <div class="config-form-group">
+        <h4>Custom Background</h4>
+        <div class="portal-bg-grid portal-bg-grid-top">
+          <div class="config-form-row">
+            <label for="app-portal-bg-url">Background URL</label>
+            <input id="app-portal-bg-url" type="text" placeholder="/static/portal-background.jpg">
+          </div>
+          <div class="config-form-row">
+            <label for="app-portal-bg-mode">Background Display</label>
+            <select id="app-portal-bg-mode">
+              <option value="span">Span</option>
+              <option value="fit">Fit</option>
+              <option value="centered">Centered</option>
+              <option value="original">Original</option>
+              <option value="stretch">Stretch</option>
+              <option value="tile">Tile</option>
+            </select>
+          </div>
+        </div>
+      </div>
     `, `
       <div class="config-form-group">
         <h4>Buttons</h4>
@@ -481,6 +501,8 @@ export const createConfigFormsController = (configFields) => {
     setFieldValue('app-unauth-request-email', config.unauthRequestEmail || '');
     setFieldValue('app-unauth-request-subject', config.unauthRequestSubject || '');
     setFieldValue('app-portal-bg-color', config.portalBackgroundColor || '#0b1020');
+    setFieldValue('app-portal-bg-url', config.portalBackgroundUrl || '');
+    setFieldValue('app-portal-bg-mode', config.portalBackgroundMode || 'span');
     setFieldValue('app-portal-modal-color', config.portalModalColor || '#111827');
     setFieldValue('app-portal-title-color', config.portalTitleColor || '#e5e7eb');
     setFieldValue('app-portal-body-text-color', config.portalBodyTextColor || '#94a3b8');
@@ -506,7 +528,11 @@ export const createConfigFormsController = (configFields) => {
       'app-unauth-request-subject':
         'Subject line prefilled in Request Access emails from the unauthorized page.',
       'app-portal-bg-color':
-        'Background color for login, authorized, and unauthorized page backgrounds.',
+        'Background color for login, authorized, and unauthorized page backgrounds. Ignored when Background URL is set.',
+      'app-portal-bg-url':
+        'Optional background image for login, authorized, and unauthorized page backgrounds. Use a relative path or absolute https:// URL.',
+      'app-portal-bg-mode':
+        'Controls how the background image is placed. Span fills the screen, Fit keeps the whole image visible, Original uses the natural image size.',
       'app-portal-modal-color':
         'Modal card color for login, authorized, and unauthorized pages.',
       'app-portal-title-color':
@@ -598,6 +624,8 @@ export const createConfigFormsController = (configFields) => {
     unauthRequestEmail: readFieldValue('app-unauth-request-email'),
     unauthRequestSubject: readFieldValue('app-unauth-request-subject'),
     portalBackgroundColor: readFieldValue('app-portal-bg-color') || '#0b1020',
+    portalBackgroundUrl: readFieldValue('app-portal-bg-url'),
+    portalBackgroundMode: readFieldValue('app-portal-bg-mode') || 'span',
     portalModalColor: readFieldValue('app-portal-modal-color') || '#111827',
     portalTitleColor: readFieldValue('app-portal-title-color') || '#e5e7eb',
     portalBodyTextColor: readFieldValue('app-portal-body-text-color') || '#94a3b8',

--- a/auth-portal/static/styles.css
+++ b/auth-portal/static/styles.css
@@ -33,6 +33,33 @@ body.modal-open{overflow:hidden;}
 .bg.bg-mode-solid{
   background: var(--portal-bg-color);
 }
+.bg.bg-mode-image{
+  background-image:
+    linear-gradient(180deg, rgba(11,16,32,.36), rgba(11,16,32,.62)),
+    var(--portal-bg-image);
+  background-position: center, center;
+  background-size: cover, cover;
+  background-repeat: no-repeat, no-repeat;
+  background-color: var(--portal-bg-color);
+}
+.bg.bg-mode-image.bg-image-fit{
+  background-size: cover, contain;
+}
+.bg.bg-mode-image.bg-image-centered{
+  background-size: cover, auto;
+}
+.bg.bg-mode-image.bg-image-original{
+  background-position: center, left top;
+  background-size: cover, auto;
+}
+.bg.bg-mode-image.bg-image-stretch{
+  background-size: cover, 100% 100%;
+}
+.bg.bg-mode-image.bg-image-tile{
+  background-position: center, left top;
+  background-size: cover, auto;
+  background-repeat: no-repeat, repeat;
+}
 
 /* Animated film grain (very subtle) */
 .bg::after{

--- a/auth-portal/static/styles.css
+++ b/auth-portal/static/styles.css
@@ -22,6 +22,8 @@ body.modal-open{overflow:hidden;}
 /* Layered gradients for rich depth */
 .bg{
   position: relative;
+  display: flex;
+  flex-direction: column;
   min-height: 100vh;
   background:
     radial-gradient(70% 60% at 10% 10%, #1e293b 0%, transparent 60%),
@@ -64,7 +66,7 @@ body.modal-open{overflow:hidden;}
 /* Animated film grain (very subtle) */
 .bg::after{
   content:"";
-  position:absolute; inset:0;
+  position:fixed; inset:0;
   background-image: repeating-radial-gradient(rgba(255,255,255,.012) 0 1px, transparent 2px 4px);
   opacity:.25;
   mix-blend-mode: soft-light;
@@ -86,7 +88,7 @@ body.modal-open{overflow:hidden;}
 }
 
 /* ========== Layout ========== */
-.center{min-height:100%;display:grid;place-items:center;padding:2rem;position:relative;z-index:1}
+.center{flex:1;min-height:0;display:grid;place-items:center;padding:2rem;position:relative;z-index:1}
 
 .card{
   width:100%;max-width:520px;
@@ -279,7 +281,7 @@ h1{font-size:1.6rem;margin:0}
 
 /* ========== Footer ========== */
 .footer{
-  position:fixed;left:0;right:0;bottom:0;
+  flex-shrink:0;
   display:flex;justify-content:center;align-items:center;
   padding:14px 10px;font-size:14px;color:#8b8f99;z-index:1;
   background: linear-gradient(to top, rgba(11,16,32,.55), rgba(11,16,32,0));

--- a/auth-portal/templates/admin.html
+++ b/auth-portal/templates/admin.html
@@ -285,7 +285,7 @@
                                 <div class="panel-section-head">
                                     <div class="panel-section-title">
                                         <h3>Portal Styling</h3>
-                                        <button type="button" class="section-info-icon" aria-label="Portal styling info" title="Portal styling info" data-tooltip="Adjust the end-user portal background and modal card colors. Admin pages are not affected.">i</button>
+                                        <button type="button" class="section-info-icon" aria-label="Portal styling info" title="Portal styling info" data-tooltip="Adjust end-user portal colors and optional custom background image settings. Admin pages are not affected.">i</button>
                                     </div>
                                 </div>
                                 <div id="app-settings-style-fields" class="config-fields"></div>

--- a/auth-portal/templates/login.html
+++ b/auth-portal/templates/login.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="{{ .PortalLogoURL }}">
   <link rel="stylesheet" href="/static/styles.css">
 </head>
-<body class="bg {{.HeroBackgroundMode}}" style="--portal-bg-color: {{.HeroBackgroundColor}};">
+<body class="bg {{.HeroBackgroundMode}}" style="{{.HeroBackgroundStyle}}">
   <main class="center">
     <section class="card {{.PortalCardMode}}" style="--portal-card-color: {{.PortalCardColor}};">
       <div class="brand">

--- a/auth-portal/templates/mfa_challenge.html
+++ b/auth-portal/templates/mfa_challenge.html
@@ -18,7 +18,7 @@
     .btn-row { display: flex; justify-content: center; margin-top: 0.5rem; }
   </style>
 </head>
-<body class="bg {{.HeroBackgroundMode}}" style="--portal-bg-color: {{.HeroBackgroundColor}};">
+<body class="bg {{.HeroBackgroundMode}}" style="{{.HeroBackgroundStyle}}">
   <div class="page-frame">
     <main class="page-content">
       <section class="card mfa-card {{.PortalCardMode}}" style="--portal-card-color: {{.PortalCardColor}};">

--- a/auth-portal/templates/mfa_enroll.html
+++ b/auth-portal/templates/mfa_enroll.html
@@ -26,7 +26,7 @@
     .btn-row { display: flex; justify-content: center; margin-top: 0.5rem; }
   </style>
 </head>
-<body class="bg {{.HeroBackgroundMode}}" style="--portal-bg-color: {{.HeroBackgroundColor}};">
+<body class="bg {{.HeroBackgroundMode}}" style="{{.HeroBackgroundStyle}}">
   <div class="page-frame">
     <main class="page-content">
       <section class="card mfa-card {{.PortalCardMode}}" style="--portal-card-color: {{.PortalCardColor}};">

--- a/auth-portal/templates/portal_authorized.html
+++ b/auth-portal/templates/portal_authorized.html
@@ -7,7 +7,7 @@
   <link rel="icon" href="{{ .PortalLogoURL }}">
   <link rel="stylesheet" href="/static/styles.css">
 </head>
-<body class="bg {{.HeroBackgroundMode}}" style="--portal-bg-color: {{.HeroBackgroundColor}};">
+<body class="bg {{.HeroBackgroundMode}}" style="{{.HeroBackgroundStyle}}">
   <main class="center">
     <section class="card {{.PortalCardMode}}" style="--portal-card-color: {{.PortalCardColor}};">
       <div class="brand">

--- a/auth-portal/templates/portal_unauthorized.html
+++ b/auth-portal/templates/portal_unauthorized.html
@@ -7,7 +7,7 @@
   <link rel="icon" href="{{ .PortalLogoURL }}">
   <link rel="stylesheet" href="/static/styles.css">
 </head>
-<body class="bg {{.HeroBackgroundMode}}" style="--portal-bg-color: {{.HeroBackgroundColor}};">
+<body class="bg {{.HeroBackgroundMode}}" style="{{.HeroBackgroundStyle}}">
   <main class="center">
     <section class="card {{.PortalCardMode}}" style="--portal-card-color: {{.PortalCardColor}};">
       <div class="brand">


### PR DESCRIPTION
**Summary**
Adds App Settings support for a custom portal background image,
including display mode controls, documentation updates, and a layout fix
for transient portal overflow.

**Description**
This PR adds configurable custom background image support for the
end-user portal pages.

**Changes include:**

- Added portalBackgroundUrl to override the default portal background
color with a custom image URL.
- Added portalBackgroundMode with display options: span, fit, centered,
original, stretch, and tile.
- Added Admin UI controls under App Settings -> Portal Styling -> Custom
Background.
- Kept color controls separate so portalBackgroundColor is overridden
only when a custom background URL is set.
- Applied the custom background behavior across login, authorized,
unauthorized, and MFA pages.
- Added validation and tests for background URL and display mode
settings.
- Updated README, sample env defaults, admin help text, and changelog.
- Fixed transient vertical overflow on the authorized portal page by
adjusting portal layout and the animated grain layer.