### PR TITLE
fix(ci): enforce HTTPS for tool downloads

### DIFF
--- a/.github/workflows/build-and-publish-auth-portal.yml
+++ b/.github/workflows/build-and-publish-auth-portal.yml
@@ -154,7 +154,7 @@ jobs:
           SYFT_VERSION="v1.42.4"
           SYFT_SHA256="590650c2743b83f327d1bf9bec64f6f83b7fec504187bb84f500c862bf8f2a0f"
           SYFT_URL="https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/syft_${SYFT_VERSION#v}_linux_amd64.tar.gz"
-          curl -sSfL "$SYFT_URL" -o /tmp/syft.tgz
+          curl --proto '=https' --proto-redir '=https' -sSfL "$SYFT_URL" -o /tmp/syft.tgz
           echo "${SYFT_SHA256}  /tmp/syft.tgz" | sha256sum -c -
           tar -xzf /tmp/syft.tgz -C /tmp syft
           install /tmp/syft "$HOME/.local/bin/syft"
@@ -186,7 +186,7 @@ jobs:
           GRYPE_VERSION="v0.110.0"
           GRYPE_SHA256="aaa98d27d2d7efd9317c6a1ad6d9b15f3e65bab320e7d03bde41e251387bb71c"
           GRYPE_URL="https://github.com/anchore/grype/releases/download/${GRYPE_VERSION}/grype_${GRYPE_VERSION#v}_linux_amd64.tar.gz"
-          curl -sSfL "$GRYPE_URL" -o /tmp/grype.tgz
+          curl --proto '=https' --proto-redir '=https' -sSfL "$GRYPE_URL" -o /tmp/grype.tgz
           echo "${GRYPE_SHA256}  /tmp/grype.tgz" | sha256sum -c -
           tar -xzf /tmp/grype.tgz -C /tmp grype
           install /tmp/grype "$HOME/.local/bin/grype"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Updated the Go toolchain and Docker builder image to Go 1.26.5, and upgraded `golang.org/x/crypto` to v0.52.0 to pick up current CVE fixes.
 - Updated pinned GitHub Actions build dependencies, including Checkout, Cache, Buildx, TruffleHog, and the GitHub release action.
+- Enforced HTTPS for Syft and Grype download redirects in the build workflow.
 - Prevented the authorized portal page from showing transient vertical overflow when moving the mouse by letting the portal layout reserve footer space and keeping the animated grain layer out of scrollable layout.
 
 ## v2.0.5 - 2026-04-08


### PR DESCRIPTION
Restrict Syft and Grype downloads and redirects to HTTPS to satisfy SonarQube security checks while retaining SHA-256 verification.